### PR TITLE
fix last oracle update time - substrate returns milliseconds

### DIFF
--- a/src/apis/oracle.ts
+++ b/src/apis/oracle.ts
@@ -26,7 +26,7 @@ export interface OracleAPI {
 }
 
 export class DefaultOracleAPI implements OracleAPI {
-    constructor(private api: ApiPromise) { }
+    constructor(private api: ApiPromise) {}
 
     async getInfo(): Promise<OracleInfo> {
         const results = await this.api.queryMulti([
@@ -80,7 +80,7 @@ export class DefaultOracleAPI implements OracleAPI {
     }
 
     private convertMoment(moment: Moment): Date {
-        return new Date(moment.toNumber() * 1000);
+        return new Date(moment.toNumber());
     }
 
     private convertExchangeRate(rate: u128): number {

--- a/test/unit/apis/oracle.test.ts
+++ b/test/unit/apis/oracle.test.ts
@@ -60,7 +60,7 @@ describe("oracle", () => {
 
     describe("getLastExchangeRateTime", () => {
         it("should return result as a date", () => {
-            const expected = Math.floor(lastRate.getTime() / 1000) * 1000;
+            const expected = Math.floor(lastRate.getTime() / 1000);
             const actual = oracle.getLastExchangeRateTime().then((v) => v.getTime());
             return assert.eventually.equal(actual, expected);
         });


### PR DESCRIPTION
Signed-off-by: Gregory Hill <gregorydhill@outlook.com>