### PR TITLE
fix(import): avoid exporting the setup script

### DIFF
--- a/src/factory.ts
+++ b/src/factory.ts
@@ -29,9 +29,9 @@ export function createPolkadotAPI(endpoint: string, autoConnect?: number | false
 export async function createInterbtcAPI(
     endpoint: string,
     network: BitcoinNetwork = "mainnet",
+    indexEndpoint?: string,
     account?: AddressOrPair,
-    autoConnect?: number | false | undefined,
-    indexEndpoint?: string
+    autoConnect?: number | false | undefined
 ): Promise<InterBTCAPI> {
     const api = await createPolkadotAPI(endpoint, autoConnect);
     return new DefaultInterBTCAPI(api, network, account, indexEndpoint);

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -5,4 +5,3 @@ export * from "./constants";
 export * from "./bitcoin-core-client";
 export * from "./issueRedeem";
 export * from "./storage";
-export * from "./setup";


### PR DESCRIPTION
to prevent issues when the library is used as a module rather than an executable