### PR TITLE
fix(escrow): Saturating subtraction

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@interlay/interbtc-api",
-  "version": "1.5.12",
+  "version": "1.5.13",
   "description": "JavaScript library to interact with interBTC and kBTC",
   "main": "build/src/index.js",
   "typings": "build/src/index.d.ts",

--- a/src/parachain/escrow.ts
+++ b/src/parachain/escrow.ts
@@ -133,8 +133,14 @@ export class DefaultEscrowAPI extends DefaultTransactionAPI implements EscrowAPI
         Rust reference implementation:
         https://github.com/interlay/interbtc/blob/0302612ae5f8ddf1f556042ca347c6104704ad83/crates/escrow/src/lib.rs#L524
     */
-        const heightDiff = new BN(height).sub(escrowPoint.ts);
-        return escrowPoint.bias.sub(escrowPoint.slope.mul(heightDiff));
+        const heightDiff = this.saturatingSub(
+            new BN(height),
+            escrowPoint.ts
+        );
+        return this.saturatingSub(
+            escrowPoint.bias,
+            escrowPoint.slope.mul(heightDiff)
+        );
     }
 
     async totalVotingSupply(
@@ -176,8 +182,11 @@ export class DefaultEscrowAPI extends DefaultTransactionAPI implements EscrowAPI
                 d_slope = this.getSlopeChange(slopeChanges, t_i);
             }
 
-            const heightDiff = t_i.sub(lastPoint.ts);
-            lastPoint.bias = lastPoint.bias.sub(lastPoint.slope.mul(heightDiff));
+            const heightDiff = this.saturatingSub(t_i, lastPoint.ts);
+            lastPoint.bias = this.saturatingSub(
+                lastPoint.bias,
+                lastPoint.slope.mul(heightDiff)
+            );
 
             if (t_i.eq(height)) {
                 break;
@@ -208,6 +217,10 @@ export class DefaultEscrowAPI extends DefaultTransactionAPI implements EscrowAPI
             d_slope = new BN(0);
         }
         return d_slope;
+    }
+
+    private saturatingSub(x: BN, y: BN): BN {
+        return BN.max(x.sub(y), new BN(0));
     }
 
 }

--- a/test/integration/parachain/staging/escrow.test.ts
+++ b/test/integration/parachain/staging/escrow.test.ts
@@ -2,7 +2,7 @@ import { ApiPromise, Keyring } from "@polkadot/api";
 
 import { createPolkadotAPI } from "../../../../src/factory";
 import { ORACLE_URI, PARACHAIN_ENDPOINT, USER_1_URI, USER_2_URI, VAULT_TO_BAN_URI } from "../../../config";
-import { DefaultEscrowAPI, DefaultFeeAPI, DefaultOracleAPI, DefaultSystemAPI, DefaultTokensAPI, EscrowAPI, FeeAPI, newAccountId, newMonetaryAmount, SystemAPI, TokensAPI } from "../../../../src";
+import { DefaultEscrowAPI, DefaultSystemAPI, DefaultTokensAPI, EscrowAPI, FeeAPI, newAccountId, newMonetaryAmount, SystemAPI, TokensAPI } from "../../../../src";
 import { assert } from "chai";
 import { Interlay } from "@interlay/monetary-js";
 import { KeyringPair } from "@polkadot/keyring/types";
@@ -32,6 +32,16 @@ describe("escrow", () => {
     after(async () => {
         api.disconnect();
     });
+
+    // PRECONDITION: This test must run first, so no tokens are locked.
+    it("Non-negative voting supply", async () => {
+        const totalVotingSupply = await escrowAPI.totalVotingSupply();
+        assert.equal(
+            totalVotingSupply.toString(),
+            "0",
+            "Voting supply balance should be zero before any tokens are locked"
+        );
+    }).timeout(100000);
 
     it("should compute voting balance and total supply", async () => {
         const user1_intrAmount = newMonetaryAmount(1000, Interlay, true);


### PR DESCRIPTION
Subtractions of the voting balances were done without saturation, causing them to be negative in some cases.

Thank you to @wliyongfeng for reporting!