### PR TITLE
chore: move unused scripts outside `src`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@interlay/interbtc-api",
-  "version": "1.5.14",
+  "version": "1.5.15",
   "description": "JavaScript library to interact with interBTC and kBTC",
   "main": "build/src/index.js",
   "typings": "build/src/index.d.ts",
@@ -27,8 +27,8 @@
     "generate:defs": "ts-node --skip-project node_modules/.bin/polkadot-types-from-defs --package @interlay/interbtc/interfaces --input ./src/interfaces --endpoint ./src/json/parachain.json",
     "generate:meta": "ts-node --skip-project node_modules/.bin/polkadot-types-from-chain --package @interlay/interbtc/interfaces --endpoint ./src/json/parachain.json --output ./src/interfaces",
     "initialize": "run-s build && ts-node src/utils/setup --initialize",
-    "hrmp-setup": "ts-node src/utils/hrmp-setup",
-    "xcm-cross-chain-transfer": "ts-node src/utils/xcm-cross-chain-transfer",
+    "hrmp-setup": "ts-node scripts/hrmp-setup",
+    "xcm-cross-chain-transfer": "ts-node scripts/xcm-cross-chain-transfer",
     "test": "run-s build test:*",
     "test:lint": "eslint src --ext .ts",
     "test:unit": "mocha test/unit/*.test.ts test/unit/**/*.test.ts",

--- a/scripts/hrmp-setup.ts
+++ b/scripts/hrmp-setup.ts
@@ -1,9 +1,9 @@
 /* eslint @typescript-eslint/no-var-requires: "off" */
-import { createPolkadotAPI } from "../factory";
+import { createPolkadotAPI } from "../src/factory";
 import { ApiPromise, Keyring } from "@polkadot/api";
 import {
     DefaultTransactionAPI,
-} from "../parachain";
+} from "../src/parachain";
 import { cryptoWaitReady } from "@polkadot/util-crypto";
 import { XcmVersionedXcm } from "@polkadot/types/lookup";
 import { XcmVersionedMultiLocation } from "@polkadot/types/lookup";

--- a/scripts/xcm-cross-chain-transfer.ts
+++ b/scripts/xcm-cross-chain-transfer.ts
@@ -1,9 +1,9 @@
 /* eslint @typescript-eslint/no-var-requires: "off" */
-import { createPolkadotAPI } from "../factory";
+import { createPolkadotAPI } from "../src/factory";
 import { Keyring } from "@polkadot/api";
 import {
     DefaultTransactionAPI,
-} from "../parachain";
+} from "../src/parachain";
 import { cryptoWaitReady } from "@polkadot/util-crypto";
 import { XcmVersionedMultiLocation } from "@polkadot/types/lookup";
 import { XcmV1MultiLocation } from "@polkadot/types/lookup";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -35,9 +35,6 @@
     ],
     "exclude": [
         "./node_modules/*",
-        "./src/utils/hrmp-setup.ts",
-        "./src/utils/xcm-cross-chain-transfer.ts",
-        "./src/utils/setup.ts",
-
+        "scripts/*"
     ]
 }


### PR DESCRIPTION
Scripts were causing import errors downstream. Moved them outside of `src`