### PR TITLE
fix: check for locktime increase in reward estimation function and consider locktime and balance in reward share

### DIFF
--- a/src/parachain/escrow.ts
+++ b/src/parachain/escrow.ts
@@ -184,10 +184,10 @@ export class DefaultEscrowAPI implements EscrowAPI {
             // Case 2: user only plans to extend the lock
             if ((amountToLock === undefined || amountToLock.isZero()) && unlockHeight) {
                 // Note: unlockHeight - currentBlockNumber should not be <0
-                addedStake.add(unlockHeight - currentBlockNumber);
+                addedStake = new Big(unlockHeight - currentBlockNumber);
             // Case 3: user only plans to increase their stake
             } else if ((unlockHeight === undefined || 0) && amountToLock) {
-                addedStake.add(amountToLock.toBig());
+                addedStake = amountToLock.toBig();
             // Case 4: user extends both locktime and increases stake
             } else if (amountToLock && unlockHeight) {
                 addedStake = amountToLock.toBig().mul(unlockHeight - currentBlockNumber);

--- a/test/integration/parachain/staging/escrow.test.ts
+++ b/test/integration/parachain/staging/escrow.test.ts
@@ -53,7 +53,7 @@ describe("escrow", () => {
         assert.isTrue(rewardsEstimate.amount.isZero(), "Rewards should be 0");
     });
 
-    it("should compute voting balance and total supply", async () => {
+    it.only("should compute voting balance and total supply", async () => {
         const user1_intrAmount = newMonetaryAmount(1000, Interlay, true);
         const user2_intrAmount = newMonetaryAmount(600, Interlay, true);
         const chargedFees = newMonetaryAmount(1, Interlay, true);


### PR DESCRIPTION
This PR updates the reward estimation to account for https://github.com/interlay/interbtc/pull/470. In this change, the reward pool share is calculated via the remaining locktime and the locked balanced (not just the locked balance).
The reward estimation now reflects that.

The minor update removes the finalized block `await` for reward estimation as it's fine to do this on non-finalized blocks and will save us network time.