### PR TITLE
fix: escrow api fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "@interlay/interbtc-api",
-  "version": "1.6.1",
+  "name": "@interlay/interbtc",
+  "version": "1.7.0",
   "description": "JavaScript library to interact with interBTC and kBTC",
   "main": "build/src/index.js",
   "typings": "build/src/index.d.ts",
-  "repository": "https://github.com/interlay/interbtc-js",
+  "repository": "https://github.com/interlay/interbtc-api",
   "license": "Apache-2.0",
   "keywords": [
     "Polkadot",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@interlay/interbtc",
+  "name": "@interlay/interbtc-api",
   "version": "1.7.0",
   "description": "JavaScript library to interact with interBTC and kBTC",
   "main": "build/src/index.js",

--- a/src/parachain/escrow.ts
+++ b/src/parachain/escrow.ts
@@ -162,7 +162,7 @@ export class DefaultEscrowAPI implements EscrowAPI {
 
         // If there is nothing staked in the system or
         // no rewards are paid, the rewards are 0
-        if (newTotalStake.isZero() || blockReward.isZero()) {
+        if (newUserStake.isZero() || blockReward.isZero()) {
             return {
                 amount: newMonetaryAmount(
                     0,

--- a/src/parachain/escrow.ts
+++ b/src/parachain/escrow.ts
@@ -2,6 +2,7 @@ import { Currency, MonetaryAmount } from "@interlay/monetary-js";
 import { ApiPromise } from "@polkadot/api";
 import { AccountId } from "@polkadot/types/interfaces";
 import BN from "bn.js";
+import Big from "big.js";
 
 import { newMonetaryAmount, storageKeyToNthInner, toVoting } from "../utils";
 import {
@@ -93,7 +94,7 @@ export interface EscrowAPI {
         amountToLock?: MonetaryAmount<Currency<U>, U>
     ): Promise<{
             amount: MonetaryAmount<Currency<U>, U>,
-            apy: number
+            apy: Big
     }>;
 }
 
@@ -139,7 +140,7 @@ export class DefaultEscrowAPI implements EscrowAPI {
         amountToLock?: MonetaryAmount<Currency<U>, U>
     ): Promise<{
             amount: MonetaryAmount<Currency<U>, U>,
-            apy: number
+            apy: Big
     }> {
         const [userStake, totalStake, blockReward, stakedBalance, currentBlockNumber] = await Promise.all([
             this.getEscrowStake(accountId),
@@ -167,7 +168,7 @@ export class DefaultEscrowAPI implements EscrowAPI {
                     0,
                     this.governanceCurrency as Currency<GovernanceUnit>
                 ) as unknown as MonetaryAmount<Currency<U>, U>,
-                apy: 0
+                apy: new Big(0)
             };
         }
 
@@ -178,7 +179,7 @@ export class DefaultEscrowAPI implements EscrowAPI {
 
         return {
             amount: rewardAmount,
-            apy: rewardAmount.toBig().div(newAmountLocked.toBig()).toNumber()
+            apy: rewardAmount.toBig().div(newAmountLocked.toBig()).mul(100)
         };
     }
 

--- a/src/parachain/escrow.ts
+++ b/src/parachain/escrow.ts
@@ -4,7 +4,7 @@ import { AccountId } from "@polkadot/types/interfaces";
 import BN from "bn.js";
 import Big from "big.js";
 
-import { newMonetaryAmount, storageKeyToNthInner, toVoting } from "../utils";
+import { decodeFixedPointType, newCurrencyId, newMonetaryAmount, storageKeyToNthInner, toVoting } from "../utils";
 import {
     GovernanceCurrency,
     GovernanceUnit,
@@ -12,6 +12,7 @@ import {
     parseEscrowPoint,
     RWEscrowPoint,
     StakedBalance,
+    tickerToCurrencyIdLiteral,
     VoteUnit
 } from "../types";
 import { SystemAPI } from "./system";
@@ -86,12 +87,21 @@ export interface EscrowAPI {
     ): Promise<void>;
     /**
      * @param accountId User account ID
+     * @returns The rewards that can be withdrawn by the account
+     * @remarks Implements https://spec.interlay.io/spec/reward.html#computereward
+     */
+    getRewards<U extends GovernanceUnit>(
+        accountId: AccountId,
+    ): Promise<MonetaryAmount<Currency<U>, U>>;
+    /**
+     * @param accountId User account ID
      * @param amountToLock New amount to add to the current stake
      * @returns The estimated reward, as amount and percentage (APY)
      */
     getRewardEstimate<U extends GovernanceUnit>(
         accountId: AccountId,
-        amountToLock?: MonetaryAmount<Currency<U>, U>
+        amountToLock?: MonetaryAmount<Currency<U>, U>,
+        unlockHeight?: number
     ): Promise<{
             amount: MonetaryAmount<Currency<U>, U>,
             apy: Big
@@ -135,9 +145,26 @@ export class DefaultEscrowAPI implements EscrowAPI {
         await this.transactionAPI.sendLogged(tx, this.api.events.escrow.Deposit, true);
     }
 
+    async getRewards<U extends GovernanceUnit>(accountId: AccountId): Promise<MonetaryAmount<Currency<U>, U>> {
+        // Step 1. Get amount in reward pool for the account ID
+        const [rewardStake, rewardPerToken, rewardTally] = await Promise.all([
+            this.getEscrowStake(accountId),
+            this.getRewardPerToken(),
+            this.getRewardTally(accountId)
+        ]);
+        // Step 2. Calculate the rewards that can be withdrawn at the moment
+        // Stake[currencyId, accountId] * RewardPerToken[currencyId] - RewardTally[currencyId, accountId]
+        const rewards = rewardStake.mul(rewardPerToken).sub(rewardTally);
+        return newMonetaryAmount(
+            rewards,
+            this.governanceCurrency as unknown as Currency<U>
+        );
+    }
+
     async getRewardEstimate<U extends GovernanceUnit>(
         accountId: AccountId,
-        amountToLock?: MonetaryAmount<Currency<U>, U>
+        amountToLock?: MonetaryAmount<Currency<U>, U>,
+        unlockHeight?: number
     ): Promise<{
             amount: MonetaryAmount<Currency<U>, U>,
             apy: Big
@@ -149,48 +176,106 @@ export class DefaultEscrowAPI implements EscrowAPI {
             this.getStakedBalance(accountId),
             this.systemAPI.getCurrentBlockNumber()
         ]);
-        const definedAmountToLock =
-            (
-                amountToLock
-                || newMonetaryAmount(0, this.governanceCurrency as Currency<GovernanceUnit>)
-            ) as typeof userStake;
-        const newUserStake = userStake.add(definedAmountToLock);
 
-        const newAmountLocked = stakedBalance.amount.add(definedAmountToLock);
-        const newTotalStake = totalStake.add(definedAmountToLock);
-        const lockDuration = stakedBalance.endBlock - currentBlockNumber;
+        // Note: the parachain uses the balance_at which combines the staked amount
+        // and staked time to calculate the share in the reward pool
+        // like `amountLocked * unlockHeight`
+        // https://github.com/interlay/interbtc/blob/1.7.3/crates/escrow/src/lib.rs#L525
+        // We need to differentiate four cases:
+        // 1. The user does not add any new stake/extend their lock time
+        // 2. The user extends the locktime and increases the stake
+        // 3. The user increases only their stake
+        // 4. The user extends only the locktime
+
+        // Case 1: no change
+        // actual tokens staked and unlock height
+        const newStakedBalance = stakedBalance;
+        // user_staked_tokens * unlock_height
+        let newUserStake = userStake;
+        // total_staked_tokens * unlock_heights
+        let newTotalStake = totalStake;
+        let newLockDuration = newStakedBalance.endBlock - currentBlockNumber;
+        // Case 2: update stake an unlock height
+        if (amountToLock && unlockHeight) {
+            const monetaryAddedStake = newMonetaryAmount(amountToLock.toBig(), this.governanceCurrency as Currency<GovernanceUnit>);
+            newStakedBalance.amount = stakedBalance.amount.add(monetaryAddedStake);
+            newStakedBalance.endBlock = unlockHeight;
+
+            newLockDuration = newStakedBalance.endBlock - currentBlockNumber;
+            const newStake = amountToLock.toBig().mul(newLockDuration);
+            newUserStake = userStake.add(newStake);
+            newTotalStake = totalStake.add(newStake);
+        // Case 3: update stake only
+        } else if (amountToLock && !unlockHeight) {
+            const monetaryAddedStake = newMonetaryAmount(amountToLock.toBig(), this.governanceCurrency as Currency<GovernanceUnit>);
+            newStakedBalance.amount = stakedBalance.amount.add(monetaryAddedStake);
+
+            const newStake = amountToLock.toBig();
+            newUserStake = userStake.add(newStake);
+            newTotalStake = totalStake.add(newStake);
+        // Case 4: update unlock height only
+        } else if (!amountToLock && unlockHeight) {
+            newLockDuration = newStakedBalance.endBlock - currentBlockNumber;
+            const newStake = new Big(newLockDuration);
+            newUserStake = userStake.add(newStake);
+            newTotalStake = totalStake.add(newStake);
+        }
 
         // If there is nothing staked in the system or
         // no rewards are paid, the rewards are 0
-        if (newUserStake.isZero() || blockReward.isZero()) {
+        if (newUserStake.eq(0) || blockReward.isZero()) {
             return {
                 amount: newMonetaryAmount(
                     0,
-                    this.governanceCurrency as Currency<GovernanceUnit>
-                ) as unknown as MonetaryAmount<Currency<U>, U>,
+                    this.governanceCurrency as unknown as Currency<U>
+                ),
                 apy: new Big(0)
             };
         }
 
         const rewardAmount = newUserStake
-            .div(newTotalStake.toBig())
+            .div(newTotalStake)
             .mul(blockReward.toBig())
-            .mul(lockDuration) as unknown as MonetaryAmount<Currency<U>, U>;
+            .mul(newLockDuration);
+
+        const monetaryRewardAmount = newMonetaryAmount(rewardAmount, this.governanceCurrency as unknown as Currency<U>);
 
         return {
-            amount: rewardAmount,
-            apy: rewardAmount.toBig().div(newAmountLocked.toBig()).mul(100)
+            amount: monetaryRewardAmount,
+            apy: rewardAmount.div(newStakedBalance.amount.toBig()).mul(100)
         };
     }
 
-    async getEscrowStake(accountId: AccountId): Promise<MonetaryAmount<Currency<GovernanceUnit>, GovernanceUnit>> {
+    async getEscrowStake(accountId: AccountId): Promise<Big> {
         const rawStake = await this.api.query.escrowRewards.stake(accountId);
-        return newMonetaryAmount(rawStake.toString(), this.governanceCurrency as Currency<GovernanceUnit>);
+        return decodeFixedPointType(rawStake);
     }
 
-    async getEscrowTotalStake(): Promise<MonetaryAmount<Currency<GovernanceUnit>, GovernanceUnit>> {
+    async getEscrowTotalStake(): Promise<Big> {
         const rawTotalStake = await this.api.query.escrowRewards.totalStake();
-        return newMonetaryAmount(rawTotalStake.toString(), this.governanceCurrency as Currency<GovernanceUnit>);
+        return decodeFixedPointType(rawTotalStake);
+    }
+
+    async getRewardTally(accountId: AccountId): Promise<Big> {
+        const governanceCurrencyId = newCurrencyId(
+            this.api,
+            tickerToCurrencyIdLiteral(
+                this.governanceCurrency.ticker
+            )
+        );
+        const rawRewardTally = await this.api.query.escrowRewards.rewardTally(governanceCurrencyId, accountId);
+        return decodeFixedPointType(rawRewardTally);
+    }
+
+    async getRewardPerToken(): Promise<Big> {
+        const governanceCurrencyId = newCurrencyId(
+            this.api,
+            tickerToCurrencyIdLiteral(
+                this.governanceCurrency.ticker
+            )
+        );
+        const rawRewardPerToken = await this.api.query.escrowRewards.rewardPerToken(governanceCurrencyId);
+        return decodeFixedPointType(rawRewardPerToken);
     }
 
     async getRewardPerBlock(): Promise<MonetaryAmount<Currency<GovernanceUnit>, GovernanceUnit>> {

--- a/src/parachain/issue.ts
+++ b/src/parachain/issue.ts
@@ -128,6 +128,11 @@ export interface IssueAPI {
      */
     getRequestsByIds(issueIds: (H256 | string)[]): Promise<Issue[]>;
     /**
+     * @returns The minimum amount of wrapped tokens that is accepted for issue requests; any lower values would
+     * risk the bitcoin client to reject the payment
+     */
+    getDustValue(): Promise<MonetaryAmount<WrappedCurrency, BitcoinUnit>>;
+    /**
      * @returns The fee charged for issuing. For instance, "0.005" stands for 0.5%
      */
     getFeeRate(): Promise<Big>;
@@ -328,6 +333,11 @@ export class DefaultIssueAPI implements IssueAPI {
     ): Promise<MonetaryAmount<WrappedCurrency, BitcoinUnit>> {
         const feePercentage = await this.getFeeRate();
         return amount.mul(feePercentage);
+    }
+
+    async getDustValue(): Promise<MonetaryAmount<WrappedCurrency, BitcoinUnit>> {
+        const dustValueSat = await this.api.query.issue.issueBtcDustValue();
+        return newMonetaryAmount(dustValueSat.toString(), this.wrappedCurrency);
     }
 
     async getFeeRate(): Promise<Big> {

--- a/src/parachain/redeem.ts
+++ b/src/parachain/redeem.ts
@@ -334,19 +334,16 @@ export class DefaultRedeemAPI implements RedeemAPI {
     }
 
     async getFeeRate(): Promise<Big> {
-
         const redeemFee = await this.api.query.fee.redeemFee();
         return decodeFixedPointType(redeemFee);
     }
 
     async getDustValue(): Promise<MonetaryAmount<WrappedCurrency, BitcoinUnit>> {
-
         const dustValueSat = await this.api.query.redeem.redeemBtcDustValue();
         return newMonetaryAmount(dustValueSat.toString(), this.wrappedCurrency);
     }
 
     async getPremiumRedeemFeeRate(): Promise<Big> {
-
         const premiumRedeemFee = await this.api.query.fee.premiumRedeemFee();
         return decodeFixedPointType(premiumRedeemFee);
     }

--- a/src/parachain/system.ts
+++ b/src/parachain/system.ts
@@ -39,7 +39,6 @@ export class DefaultSystemAPI {
     constructor(private api: ApiPromise, private transactionAPI: TransactionAPI) {}
 
     async getCurrentBlockNumber(): Promise<number> {
-
         return (await this.api.query.system.number()).toNumber();
     }
 

--- a/test/integration/parachain/staging/escrow.test.ts
+++ b/test/integration/parachain/staging/escrow.test.ts
@@ -3,6 +3,7 @@ import { assert } from "chai";
 import { Currency } from "@interlay/monetary-js";
 import { KeyringPair } from "@polkadot/keyring/types";
 import BN from "bn.js";
+import Big from "big.js";
 
 import { createSubstrateAPI } from "../../../../src/factory";
 import { ESPLORA_BASE_PATH, PARACHAIN_ENDPOINT, SUDO_URI, VAULT_3_URI, VAULT_TO_BAN_URI, VAULT_TO_LIQUIDATE_URI } from "../../../config";
@@ -52,8 +53,8 @@ describe("escrow", () => {
     it("should return 0 reward and apy estimate", async () => {
         const rewardsEstimate = await interBtcAPI.escrow.getRewardEstimate(newAccountId(api, userAccount_1.address));
 
-        assert.equal(rewardsEstimate.apy, 0, "APY should be 0");
-        assert.isTrue(rewardsEstimate.amount.isZero(), "Rewards should be 0");
+        assert.equal(rewardsEstimate.apy, new Big(0), `APY should be 0, but is ${rewardsEstimate.apy.toString()}`);
+        assert.isTrue(rewardsEstimate.amount.isZero(), `Rewards should be 0, but are ${rewardsEstimate.amount.toHuman()}`);
     });
 
     it("should compute voting balance and total supply", async () => {
@@ -108,7 +109,7 @@ describe("escrow", () => {
             expectedRewards.toBig().div(rewardsEstimate.amount.toBig()).gt(0.9),
             "The estimate should be within 10% of the actual first year rewards"
         );
-        assert.isAbove(rewardsEstimate.apy, 1);
+        assert.isTrue(rewardsEstimate.apy.gte(100), `Expected more than 100% APY, got ${rewardsEstimate.apy.toString()}`);
 
         // Lock the tokens of a second user, to ensure total voting supply is still correct
         interBtcAPI.setAccount(userAccount_2);


### PR DESCRIPTION
- Removes a division by 0 error from the API
- Corrects the escrow reward stake to be a fixed point representation of the amount * unlock_height instead of a monetary amount
- Multiplies the APY by 100 to get a percentage back
- Adds the unlockHeight as parameter for the reward estimate
- Bumps the package version to 1.7.0