### PR TITLE
fix: Banned vaults have no redeemable tokens

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@interlay/interbtc-api",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "description": "JavaScript library to interact with interBTC and kBTC",
   "main": "build/src/index.js",
   "typings": "build/src/index.d.ts",

--- a/src/parachain/vaults.ts
+++ b/src/parachain/vaults.ts
@@ -703,7 +703,7 @@ export class DefaultVaultsAPI implements VaultsAPI {
 
     async getPremiumRedeemVaults(): Promise<
         Map<InterbtcPrimitivesVaultId, MonetaryAmount<Currency<BitcoinUnit>, BitcoinUnit>>
-    > {
+        > {
         const map: Map<InterbtcPrimitivesVaultId, MonetaryAmount<WrappedCurrency, BitcoinUnit>> = new Map();
         const vaults = await this.list();
         const premiumRedeemVaultPredicates = await Promise.all(
@@ -726,7 +726,7 @@ export class DefaultVaultsAPI implements VaultsAPI {
 
     async getVaultsWithIssuableTokens(): Promise<
         Map<InterbtcPrimitivesVaultId, MonetaryAmount<Currency<BitcoinUnit>, BitcoinUnit>>
-    > {
+        > {
         const map: Map<InterbtcPrimitivesVaultId, MonetaryAmount<WrappedCurrency, BitcoinUnit>> = new Map();
         const [vaults, activeBlockNumber] = await Promise.all([
             this.list(),
@@ -750,7 +750,7 @@ export class DefaultVaultsAPI implements VaultsAPI {
 
     async getVaultsWithRedeemableTokens(): Promise<
         Map<InterbtcPrimitivesVaultId, MonetaryAmount<WrappedCurrency, BitcoinUnit>>
-    > {
+        > {
         const map: Map<InterbtcPrimitivesVaultId, MonetaryAmount<WrappedCurrency, BitcoinUnit>> = new Map();
         const [vaults, activeBlockNumber] = await Promise.all([
             this.list(),

--- a/src/parachain/vaults.ts
+++ b/src/parachain/vaults.ts
@@ -4,7 +4,12 @@ import Big from "big.js";
 import { Network } from "bitcoinjs-lib";
 import { MonetaryAmount, Currency, BitcoinUnit } from "@interlay/monetary-js";
 import { Option } from "@polkadot/types";
-import { VaultRegistryVaultStatus, VaultRegistrySystemVault, InterbtcPrimitivesVaultId, VaultRegistryVault } from "@polkadot/types/lookup";
+import {
+    VaultRegistryVaultStatus,
+    VaultRegistrySystemVault,
+    InterbtcPrimitivesVaultId,
+    VaultRegistryVault,
+} from "@polkadot/types/lookup";
 
 import {
     decodeFixedPointType,
@@ -72,7 +77,7 @@ export interface VaultsAPI {
      * should only include the issued tokens, leaving out unsettled ("to-be-issued") tokens
      * @returns the vault collateralization
      */
-     getVaultCollateralization<C extends CollateralUnit>(
+    getVaultCollateralization<C extends CollateralUnit>(
         vaultAccountId: AccountId,
         collateralCurrencyIdLiteral: CollateralIdLiteral,
         newCollateral?: MonetaryAmount<Currency<C>, C>,
@@ -139,20 +144,25 @@ export interface VaultsAPI {
      */
     getPremiumRedeemVaults(): Promise<Map<InterbtcPrimitivesVaultId, MonetaryAmount<WrappedCurrency, BitcoinUnit>>>;
     /**
-     * @returns Vaults with issuable tokens
+     * @returns Vaults with issuable tokens, not sorted in any particular order.
+     * @remarks The result is not sorted as an attempt to randomize the assignment of requests to vaults.
      */
-    getVaultsWithIssuableTokens(): Promise<Map<InterbtcPrimitivesVaultId, MonetaryAmount<WrappedCurrency, BitcoinUnit>>>;
+    getVaultsWithIssuableTokens(): Promise<
+        Map<InterbtcPrimitivesVaultId, MonetaryAmount<WrappedCurrency, BitcoinUnit>>
+    >;
     /**
-     * @returns Vaults with redeemable tokens
+     * @returns Vaults with redeemable tokens, sorted in descending order.
      */
-    getVaultsWithRedeemableTokens(): Promise<Map<InterbtcPrimitivesVaultId, MonetaryAmount<WrappedCurrency, BitcoinUnit>>>;
+    getVaultsWithRedeemableTokens(): Promise<
+        Map<InterbtcPrimitivesVaultId, MonetaryAmount<WrappedCurrency, BitcoinUnit>>
+    >;
     /**
      * @param vaultAccountId The vault account ID
      * @param collateralCurrency The currency specification, a `Monetary.js` object
      * @param btcTxId ID of the Bitcoin transaction to check
      * @returns A bollean value
      */
-     isVaultFlaggedForTheft(
+    isVaultFlaggedForTheft(
         vaultAccountId: AccountId,
         collateralCurrencyIdLiteral: CollateralIdLiteral,
         btcTxId: string
@@ -247,10 +257,7 @@ export interface VaultsAPI {
      * @param vaultId The account of the vault to check.
      * @param btcTxId Bitcoin transaction ID
      */
-    reportVaultTheft(
-        vaultAccountId: AccountId,
-        btcTxId: string
-    ): Promise<void>;
+    reportVaultTheft(vaultAccountId: AccountId, btcTxId: string): Promise<void>;
     /**
      * @returns The wrapped currency issued by the vaults
      */
@@ -361,7 +368,10 @@ export class DefaultVaultsAPI implements VaultsAPI {
         collateralCurrencyIdLiteral: CollateralIdLiteral
     ): Promise<VaultExt<BitcoinUnit>> {
         try {
-            const collateralCurrency = currencyIdLiteralToMonetaryCurrency(this.api, collateralCurrencyIdLiteral) as CollateralCurrency;
+            const collateralCurrency = currencyIdLiteralToMonetaryCurrency(
+                this.api,
+                collateralCurrencyIdLiteral
+            ) as CollateralCurrency;
             const vaultId = newVaultId(this.api, vaultAccountId.toString(), collateralCurrency, this.wrappedCurrency);
             const vault = await this.api.query.vaultRegistry.vaults<Option<VaultRegistryVault>>(vaultId);
             if (!vault.isSome) {
@@ -377,7 +387,10 @@ export class DefaultVaultsAPI implements VaultsAPI {
         vaultAccountId: AccountId,
         collateralCurrencyIdLiteral: CollateralIdLiteral
     ): Promise<MonetaryAmount<Currency<CollateralUnit>, CollateralUnit>> {
-        const collateralCurrency = currencyIdLiteralToMonetaryCurrency(this.api, collateralCurrencyIdLiteral) as CollateralCurrency;
+        const collateralCurrency = currencyIdLiteralToMonetaryCurrency(
+            this.api,
+            collateralCurrencyIdLiteral
+        ) as CollateralCurrency;
         return this.rewardsAPI.computeCollateralInStakingPool(
             newVaultId(this.api, vaultAccountId.toString(), collateralCurrency, this.wrappedCurrency),
             vaultAccountId
@@ -415,10 +428,13 @@ export class DefaultVaultsAPI implements VaultsAPI {
         collateralCurrencyIdLiteral: CollateralIdLiteral
     ): Promise<Big> {
         const vault = await this.get(vaultAccountId, collateralCurrencyIdLiteral);
-        const collateralCurrency = currencyIdLiteralToMonetaryCurrency(this.api, collateralCurrencyIdLiteral) as CollateralCurrency;
+        const collateralCurrency = currencyIdLiteralToMonetaryCurrency(
+            this.api,
+            collateralCurrencyIdLiteral
+        ) as CollateralCurrency;
         const nominatorCollateral = await this.rewardsAPI.computeCollateralInStakingPool(
             newVaultId(this.api, vaultAccountId.toString(), collateralCurrency, this.wrappedCurrency),
-            nominatorId,
+            nominatorId
         );
         return nominatorCollateral.toBig().div(vault.backingCollateral.toBig());
     }
@@ -449,12 +465,12 @@ export class DefaultVaultsAPI implements VaultsAPI {
         vaultAccountId: AccountId,
         collateralCurrency: CollateralIdLiteral
     ): Promise<MonetaryAmount<Currency<BitcoinUnit>, BitcoinUnit>> {
-        return await this.computeReward(
+        return (await this.computeReward(
             vaultAccountId,
             vaultAccountId,
             collateralCurrency,
             tickerToCurrencyIdLiteral(this.wrappedCurrency.ticker)
-        ) as MonetaryAmount<Currency<BitcoinUnit>, BitcoinUnit>;
+        )) as MonetaryAmount<Currency<BitcoinUnit>, BitcoinUnit>;
     }
 
     async getGovernanceReward(
@@ -462,12 +478,12 @@ export class DefaultVaultsAPI implements VaultsAPI {
         vaultCollateralIdLiteral: CollateralIdLiteral,
         governanceCurrencyIdLiteral: GovernanceIdLiteral
     ): Promise<MonetaryAmount<Currency<GovernanceUnit>, GovernanceUnit>> {
-        return await this.computeReward(
+        return (await this.computeReward(
             vaultAccountId,
             vaultAccountId,
             vaultCollateralIdLiteral,
             governanceCurrencyIdLiteral
-        ) as MonetaryAmount<Currency<GovernanceUnit>, GovernanceUnit>;
+        )) as MonetaryAmount<Currency<GovernanceUnit>, GovernanceUnit>;
     }
 
     async getStakingCapacity(
@@ -479,7 +495,7 @@ export class DefaultVaultsAPI implements VaultsAPI {
             this.getCollateral(vaultAccountId, collateralCurrency),
             this.getMaxNominationRatio(
                 currencyIdToMonetaryCurrency(vault.id.currencies.collateral) as CollateralCurrency
-            )
+            ),
         ]);
         return collateral.mul(maxNominationRatio).sub(vault.backingCollateral);
     }
@@ -490,7 +506,11 @@ export class DefaultVaultsAPI implements VaultsAPI {
         if (!liquidationVault.isSome) {
             return Promise.reject("System vault could not be fetched");
         }
-        return parseSystemVault(liquidationVault.value as VaultRegistrySystemVault, this.wrappedCurrency, collateralCurrency);
+        return parseSystemVault(
+            liquidationVault.value as VaultRegistrySystemVault,
+            this.wrappedCurrency,
+            collateralCurrency
+        );
     }
 
     private isNoTokensIssuedError(e: Error): boolean {
@@ -502,7 +522,7 @@ export class DefaultVaultsAPI implements VaultsAPI {
             this.getPremiumRedeemThreshold(
                 currencyIdToMonetaryCurrency(vaultId.currencies.collateral) as CollateralCurrency
             ),
-            this.getCollateralizationFromVault(vaultId)
+            this.getCollateralizationFromVault(vaultId),
         ]);
         return vaultCollateralization.lt(premiumRedeemThreshold);
     }
@@ -543,10 +563,7 @@ export class DefaultVaultsAPI implements VaultsAPI {
         return collateralization;
     }
 
-    async getCollateralizationFromVault(
-        vaultId: InterbtcPrimitivesVaultId,
-        onlyIssued = false
-    ): Promise<Big> {
+    async getCollateralizationFromVault(vaultId: InterbtcPrimitivesVaultId, onlyIssued = false): Promise<Big> {
         const collateral = await this.computeBackingCollateral(vaultId);
         return this.getCollateralizationFromVaultAndCollateral(vaultId, collateral, onlyIssued);
     }
@@ -556,7 +573,10 @@ export class DefaultVaultsAPI implements VaultsAPI {
         newCollateral: MonetaryAmount<Currency<C>, C>,
         onlyIssued: boolean
     ): Promise<Big> {
-        const vault = await this.get(vaultId.accountId, currencyIdToLiteral(vaultId.currencies.collateral) as CollateralIdLiteral);
+        const vault = await this.get(
+            vaultId.accountId,
+            currencyIdToLiteral(vaultId.currencies.collateral) as CollateralIdLiteral
+        );
         const issuedTokens = await (onlyIssued ? Promise.resolve(vault.issuedTokens) : vault.getBackedTokens());
         if (issuedTokens.isZero()) {
             return Promise.reject("No tokens issued");
@@ -577,22 +597,18 @@ export class DefaultVaultsAPI implements VaultsAPI {
         vaultAccountId: AccountId,
         currency: Currency<C>
     ): Promise<MonetaryAmount<Currency<C>, C>> {
-        const vault = await this.get(
-            vaultAccountId,
-            tickerToCurrencyIdLiteral(currency.ticker) as CollateralIdLiteral
-        );
+        const vault = await this.get(vaultAccountId, tickerToCurrencyIdLiteral(currency.ticker) as CollateralIdLiteral);
         const issuedTokens = vault.getBackedTokens();
-        return await this.getRequiredCollateralForWrapped(
-            issuedTokens,
-            currency
-        );
+        return await this.getRequiredCollateralForWrapped(issuedTokens, currency);
     }
 
     async getRequiredCollateralForWrapped<C extends CollateralUnit>(
         wrappedAmount: MonetaryAmount<Currency<BitcoinUnit>, BitcoinUnit>,
-        currency: Currency<C>,
+        currency: Currency<C>
     ): Promise<MonetaryAmount<Currency<C>, C>> {
-        const secureCollateralThreshold = await this.getSecureCollateralThreshold(currency as unknown as CollateralCurrency);
+        const secureCollateralThreshold = await this.getSecureCollateralThreshold(
+            currency as unknown as CollateralCurrency
+        );
         const requiredCollateralInWrappedCurrency = wrappedAmount.mul(secureCollateralThreshold);
         return await this.oracleAPI.convertWrappedToCurrency(requiredCollateralInWrappedCurrency, currency);
     }
@@ -614,26 +630,32 @@ export class DefaultVaultsAPI implements VaultsAPI {
         // get [[wrapped, collateral], amount][] map
         const perCurrencyPairCollateralAmounts = await this.api.query.vaultRegistry.totalUserVaultCollateral.entries();
         // filter for wrapped === this.wrapped, as only one wrapped currency is handled at a time currently
-        const perWrappedCurrencyCollateralAmounts = perCurrencyPairCollateralAmounts.filter(([key, _val]) =>
-            currencyIdToMonetaryCurrency(key.args[0].wrapped).name === this.wrappedCurrency.name);
+        const perWrappedCurrencyCollateralAmounts = perCurrencyPairCollateralAmounts.filter(
+            ([key, _val]) => currencyIdToMonetaryCurrency(key.args[0].wrapped).name === this.wrappedCurrency.name
+        );
         // reduce from [[this.wrapped, collateral], amount][] pairs to [collateral, sumAmount][] map
-        const perCollateralCurrencyCollateralAmounts = perWrappedCurrencyCollateralAmounts.reduce((amounts, [key, amount]) => {
-            const collateralCurrency = currencyIdToMonetaryCurrency<CollateralUnit>(key.args[0].collateral);
-            let collateralAmount = newMonetaryAmount(amount.toString(), collateralCurrency);
-            if (amounts.has(collateralCurrency)) {
-                // .has() is true, hence non-null
-                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                collateralAmount = collateralAmount.add(amounts.get(collateralCurrency)!);
-            }
-            amounts.set(collateralCurrency, collateralAmount);
-            return amounts;
-        }, new Map<Currency<CollateralUnit>, MonetaryAmount<Currency<CollateralUnit>, CollateralUnit>>());
+        const perCollateralCurrencyCollateralAmounts = perWrappedCurrencyCollateralAmounts.reduce(
+            (amounts, [key, amount]) => {
+                const collateralCurrency = currencyIdToMonetaryCurrency<CollateralUnit>(key.args[0].collateral);
+                let collateralAmount = newMonetaryAmount(amount.toString(), collateralCurrency);
+                if (amounts.has(collateralCurrency)) {
+                    // .has() is true, hence non-null
+                    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                    collateralAmount = collateralAmount.add(amounts.get(collateralCurrency)!);
+                }
+                amounts.set(collateralCurrency, collateralAmount);
+                return amounts;
+            },
+            new Map<Currency<CollateralUnit>, MonetaryAmount<Currency<CollateralUnit>, CollateralUnit>>()
+        );
         // finally convert the CollateralAmount sums to issuable amounts and sum those to get the total
         const [perCollateralCurrencyIssuableAmounts, issuedAmountBtc] = await Promise.all([
             Promise.all(
-                [...perCollateralCurrencyCollateralAmounts.values()].map((collateralAmount) => this.calculateCapacity(collateralAmount))
+                [...perCollateralCurrencyCollateralAmounts.values()].map((collateralAmount) =>
+                    this.calculateCapacity(collateralAmount)
+                )
             ),
-            this.getTotalIssuedAmount()
+            this.getTotalIssuedAmount(),
         ]);
         const totalIssuableAmount = perCollateralCurrencyIssuableAmounts.reduce((acc, v) => acc.add(v));
         return totalIssuableAmount.sub(issuedAmountBtc);
@@ -654,7 +676,9 @@ export class DefaultVaultsAPI implements VaultsAPI {
         }
     }
 
-    async selectRandomVaultIssue(amount: MonetaryAmount<WrappedCurrency, BitcoinUnit>): Promise<InterbtcPrimitivesVaultId> {
+    async selectRandomVaultIssue(
+        amount: MonetaryAmount<WrappedCurrency, BitcoinUnit>
+    ): Promise<InterbtcPrimitivesVaultId> {
         const vaults = await this.getVaultsWithIssuableTokens();
         for (const [id, issuableAmount] of vaults) {
             if (issuableAmount.gte(amount)) {
@@ -664,7 +688,9 @@ export class DefaultVaultsAPI implements VaultsAPI {
         return Promise.reject(new Error("Did not find vault with sufficient collateral"));
     }
 
-    async selectRandomVaultRedeem(amount: MonetaryAmount<WrappedCurrency, BitcoinUnit>): Promise<InterbtcPrimitivesVaultId> {
+    async selectRandomVaultRedeem(
+        amount: MonetaryAmount<WrappedCurrency, BitcoinUnit>
+    ): Promise<InterbtcPrimitivesVaultId> {
         // Selects the first vault with sufficient tokens
         const vaults = await this.list();
         for (const vault of vaults) {
@@ -675,14 +701,16 @@ export class DefaultVaultsAPI implements VaultsAPI {
         return Promise.reject(new Error("Did not find vault with sufficient locked BTC"));
     }
 
-    async getPremiumRedeemVaults(): Promise<Map<InterbtcPrimitivesVaultId, MonetaryAmount<Currency<BitcoinUnit>, BitcoinUnit>>> {
+    async getPremiumRedeemVaults(): Promise<
+        Map<InterbtcPrimitivesVaultId, MonetaryAmount<Currency<BitcoinUnit>, BitcoinUnit>>
+    > {
         const map: Map<InterbtcPrimitivesVaultId, MonetaryAmount<WrappedCurrency, BitcoinUnit>> = new Map();
         const vaults = await this.list();
         const premiumRedeemVaultPredicates = await Promise.all(
-            vaults.map(vault => {
+            vaults.map((vault) => {
                 return new Promise((resolve, reject) => {
                     const redemableTokens = vault.getRedeemableTokens();
-                    if(redemableTokens.isZero()) {
+                    if (redemableTokens.isZero()) {
                         resolve(false);
                     } else {
                         this.isBelowPremiumThreshold(vault.id).then(resolve).catch(reject);
@@ -692,47 +720,51 @@ export class DefaultVaultsAPI implements VaultsAPI {
         );
         vaults
             .filter((_, index) => premiumRedeemVaultPredicates[index])
-            .forEach(vault => map.set(vault.id, vault.getRedeemableTokens()));
+            .forEach((vault) => map.set(vault.id, vault.getRedeemableTokens()));
         return map;
     }
 
-    async getVaultsWithIssuableTokens(): Promise<Map<InterbtcPrimitivesVaultId, MonetaryAmount<Currency<BitcoinUnit>, BitcoinUnit>>> {
+    async getVaultsWithIssuableTokens(): Promise<
+        Map<InterbtcPrimitivesVaultId, MonetaryAmount<Currency<BitcoinUnit>, BitcoinUnit>>
+    > {
         const map: Map<InterbtcPrimitivesVaultId, MonetaryAmount<WrappedCurrency, BitcoinUnit>> = new Map();
-        const vaults = await this.list();
+        const [vaults, activeBlockNumber] = await Promise.all([
+            this.list(),
+            this.systemAPI.getCurrentActiveBlockNumber(),
+        ]);
         const issuableTokens = await Promise.all(
             vaults
-                .map(
-                    vault => {
-                        return new Promise<[
-                    MonetaryAmount<Currency<BitcoinUnit>, BitcoinUnit>,
-                    InterbtcPrimitivesVaultId
-                ]>((resolve, _) => {
-                    if (vault.status !== VaultStatusExt.Active) {
-                        resolve(
-                            [
-                                newMonetaryAmount(0, currencyIdToMonetaryCurrency(vault.id.currencies.wrapped)),
-                                vault.id
-                            ]
-                        );
-                    }
-                    vault.getIssuableTokens().then((amount) => resolve([amount, vault.id]));
-                });
-                    }
-                ));
-        issuableTokens.forEach(([amount, vaultId]) => {
-            if (!amount.isZero()) {
-                map.set(vaultId, amount);
-            }
-        });
+                .filter((vault) => {
+                    const bannedUntilBlockNumber = vault.bannedUntil || 0;
+                    return vault.status === VaultStatusExt.Active && bannedUntilBlockNumber < activeBlockNumber;
+                })
+                .map((vault) => {
+                    return new Promise<[MonetaryAmount<Currency<BitcoinUnit>, BitcoinUnit>, InterbtcPrimitivesVaultId]>(
+                        (resolve, _) => vault.getIssuableTokens().then((amount) => resolve([amount, vault.id]))
+                    );
+                })
+        );
+        issuableTokens.forEach(([amount, vaultId]) => map.set(vaultId, amount));
         return map;
     }
 
-    async getVaultsWithRedeemableTokens(): Promise<Map<InterbtcPrimitivesVaultId, MonetaryAmount<WrappedCurrency, BitcoinUnit>>> {
+    async getVaultsWithRedeemableTokens(): Promise<
+        Map<InterbtcPrimitivesVaultId, MonetaryAmount<WrappedCurrency, BitcoinUnit>>
+    > {
         const map: Map<InterbtcPrimitivesVaultId, MonetaryAmount<WrappedCurrency, BitcoinUnit>> = new Map();
-        (await this.list())
-            .filter(vault => {
+        const [vaults, activeBlockNumber] = await Promise.all([
+            this.list(),
+            this.systemAPI.getCurrentActiveBlockNumber(),
+        ]);
+        vaults
+            .filter((vault) => {
+                const bannedUntilBlockNumber = vault.bannedUntil || 0;
                 // issuedTokens - toBeRedeemedTokens > 0
-                return vault.issuedTokens.gt(vault.toBeRedeemedTokens);
+                return (
+                    vault.issuedTokens.gt(vault.toBeRedeemedTokens) &&
+                    vault.status === VaultStatusExt.Active &&
+                    bannedUntilBlockNumber < activeBlockNumber
+                );
             })
             .sort((vault1, vault2) => {
                 // Descending order
@@ -740,7 +772,7 @@ export class DefaultVaultsAPI implements VaultsAPI {
                 const vault2Redeemable = vault2.getRedeemableTokens().toBig();
                 return vault2Redeemable.sub(vault1Redeemable).toNumber();
             })
-            .forEach(vault => map.set(vault.id, vault.getRedeemableTokens()));
+            .forEach((vault) => map.set(vault.id, vault.getRedeemableTokens()));
         return map;
     }
 
@@ -787,14 +819,13 @@ export class DefaultVaultsAPI implements VaultsAPI {
     async getAPY(vaultAccountId: AccountId, collateralCurrency: CollateralIdLiteral): Promise<Big> {
         const vault = await this.get(vaultAccountId, collateralCurrency);
         const [feesWrapped, lockedCollateral] = await Promise.all([
-            await this.getWrappedReward(
-                vaultAccountId,
-                collateralCurrency,
-            ),
-            (await this.tokensAPI.balance(
-                currencyIdToMonetaryCurrency(vault.id.currencies.collateral) as Currency<CollateralUnit>,
-                vaultAccountId
-            )).reserved,
+            await this.getWrappedReward(vaultAccountId, collateralCurrency),
+            (
+                await this.tokensAPI.balance(
+                    currencyIdToMonetaryCurrency(vault.id.currencies.collateral) as Currency<CollateralUnit>,
+                    vaultAccountId
+                )
+            ).reserved,
         ]);
         return this.feeAPI.calculateAPY(feesWrapped, lockedCollateral);
     }
@@ -805,21 +836,16 @@ export class DefaultVaultsAPI implements VaultsAPI {
     }
 
     private wrapCurrency<C extends CollateralUnit>(amount: MonetaryAmount<Currency<C>, C>): BalanceWrapper {
-        return this.api.createType(
-            "BalanceWrapper",
-            {
-                amount: this.api.createType("u128", amount.toString()),
-                currencyId: newCurrencyId(this.api, tickerToCurrencyIdLiteral(amount.currency.ticker))
-            }
-        );
+        return this.api.createType("BalanceWrapper", {
+            amount: this.api.createType("u128", amount.toString()),
+            currencyId: newCurrencyId(this.api, tickerToCurrencyIdLiteral(amount.currency.ticker)),
+        });
     }
 
     private unwrapCurrency<C extends CollateralUnit>(wrappedBalance: BalanceWrapper): MonetaryAmount<Currency<C>, C> {
         return newMonetaryAmount(
             wrappedBalance.amount.toString(),
-            currencyIdToMonetaryCurrency(
-                wrappedBalance.currencyId
-            )
+            currencyIdToMonetaryCurrency(wrappedBalance.currencyId)
         );
     }
 
@@ -854,16 +880,17 @@ export class DefaultVaultsAPI implements VaultsAPI {
             newMonetaryAmount(vault.toBeRedeemedTokens.toString(), this.wrappedCurrency),
             newMonetaryAmount(vault.toBeReplacedTokens.toString(), this.wrappedCurrency),
             replaceCollateral,
-            liquidatedCollateral,
+            liquidatedCollateral
         );
     }
 
-    async reportVaultTheft(
-        vaultAccountId: AccountId,
-        btcTxId: string
-    ): Promise<void> {
+    async reportVaultTheft(vaultAccountId: AccountId, btcTxId: string): Promise<void> {
         const txInclusionDetails = await getTxProof(this.electrsAPI, btcTxId);
-        const tx = this.api.tx.relay.reportVaultTheft(vaultAccountId, txInclusionDetails.merkleProof, txInclusionDetails.rawTx);
+        const tx = this.api.tx.relay.reportVaultTheft(
+            vaultAccountId,
+            txInclusionDetails.merkleProof,
+            txInclusionDetails.rawTx
+        );
         await this.transactionAPI.sendLogged(tx, this.api.events.relay.VaultTheft, true);
     }
 }


### PR DESCRIPTION
- simplifies filtering for `getVaultsWithIssuableTokens` and `getVaultsWithRedeemableTokens`
- banned vaults are filtered out of the issuable / redeemable tokens result