### PR TITLE
feat: do not wait for finalized head in vaults.list().

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@interlay/interbtc-api",
-  "version": "1.8.3",
+  "version": "1.8.4",
   "description": "JavaScript library to interact with interBTC and kBTC",
   "main": "build/src/index.js",
   "typings": "build/src/index.d.ts",

--- a/src/parachain/vaults.ts
+++ b/src/parachain/vaults.ts
@@ -371,8 +371,9 @@ export class DefaultVaultsAPI implements VaultsAPI {
     }
 
     async list(atBlock?: BlockHash): Promise<VaultExt<BitcoinUnit>[]> {
-        const block = atBlock || (await this.api.rpc.chain.getFinalizedHead());
-        const vaultsMap = await this.api.query.vaultRegistry.vaults.entriesAt(block);
+        const vaultsMap = await (atBlock ?
+            this.api.query.vaultRegistry.vaults.entriesAt(atBlock)
+            : this.api.query.vaultRegistry.vaults.entries());
         return Promise.all(
             vaultsMap
                 .filter((v) => v[1].isSome)


### PR DESCRIPTION
This is not necessary in the vast majority of cases (the atBlock parameter can be used to pass it explicitly if required).
Its presence was causing potential race conditions, e.g. with vaults becoming inactive in the time between a block being finalized and an issue request being made, causing the request to select an inactive vault.