### PR TITLE
fix: inactive vaults would show as active

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@interlay/interbtc-api",
-  "version": "1.8.3",
+  "version": "1.8.4",
   "description": "JavaScript library to interact with interBTC and kBTC",
   "main": "build/src/index.js",
   "typings": "build/src/index.d.ts",

--- a/src/parachain/vaults.ts
+++ b/src/parachain/vaults.ts
@@ -902,7 +902,7 @@ export class DefaultVaultsAPI implements VaultsAPI {
 
     private parseVaultStatus(status: VaultRegistryVaultStatus): VaultStatusExt {
         if (status.isActive) {
-            return status.asActive ? VaultStatusExt.Active : VaultStatusExt.Inactive;
+            return status.asActive.isTrue ? VaultStatusExt.Active : VaultStatusExt.Inactive;
         } else if (status.isLiquidated) {
             return VaultStatusExt.Liquidated;
         } else if (status.isCommittedTheft) {


### PR DESCRIPTION
The object `status.asActive` is always defined when `status.isActive` so this would always filter Vaults as active.