### PR TITLE
fix:switch to our own esplora/electrs deployment, so that we can use the txindex for opreturns

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@interlay/interbtc-api",
-  "version": "1.8.4",
+  "version": "1.8.5",
   "description": "JavaScript library to interact with interBTC and kBTC",
   "main": "build/src/index.js",
   "typings": "build/src/index.d.ts",

--- a/src/external/electrs.ts
+++ b/src/external/electrs.ts
@@ -15,7 +15,7 @@ import { TypeRegistry } from "@polkadot/types";
 import { Bytes } from "@polkadot/types";
 import { BitcoinAmount } from "@interlay/monetary-js";
 
-export const MAINNET_ESPLORA_BASE_PATH = "https://blockstream.info/api";
+export const MAINNET_ESPLORA_BASE_PATH = "https://btc-mainnet.interlay.io";
 export const TESTNET_ESPLORA_BASE_PATH = "https://btc-testnet.interlay.io";
 export const REGTEST_ESPLORA_BASE_PATH = "http://localhost:3002";
 


### PR DESCRIPTION
cc @savudani8: do you know by any chance why it was set to blockstream.info? Hopefully there's no issue with switching back, since the blockstream API doesn't support querying by opreturn.