### PR TITLE
feat: track ID in replace requests object

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@interlay/interbtc-api",
-  "version": "1.8.6",
+  "version": "1.8.7",
   "description": "JavaScript library to interact with interBTC and kBTC",
   "main": "build/src/index.js",
   "typings": "build/src/index.d.ts",

--- a/src/parachain/escrow.ts
+++ b/src/parachain/escrow.ts
@@ -220,12 +220,12 @@ export class DefaultEscrowAPI implements EscrowAPI {
 
         // Note: on first time staking the user has to provide both a increased stake and a locktime
         // otherwise, the rewards will be 0.
-        let newStakedBalance = {
+        const newStakedBalance = {
             amount: stakedBalance.amount,
             endBlock: stakedBalance.endBlock
         };
 
-        const monetaryAddedStake = newMonetaryAmount(amountToLock.toBig(), this.governanceCurrency as Currency<GovernanceUnit>)
+        const monetaryAddedStake = newMonetaryAmount(amountToLock.toBig(), this.governanceCurrency as Currency<GovernanceUnit>);
         // User staking for the first time; only case 2 relevant otherwise rewards should be 0
         if (stakedBalance.amount.isZero()) {
             newStakedBalance.amount = monetaryAddedStake;
@@ -235,11 +235,11 @@ export class DefaultEscrowAPI implements EscrowAPI {
             // might add 0 to either amount or endBlock
             newStakedBalance.amount = stakedBalance.amount.add(monetaryAddedStake);
             newStakedBalance.endBlock = stakedBalance.endBlock + blockLockTimeExtension;
-        };
+        }
         let newLockDuration = 0;
         if (newStakedBalance.endBlock - currentBlockNumber > 0) {
             newLockDuration = newStakedBalance.endBlock - currentBlockNumber;
-        };
+        }
 
         const newUserStake = newStakedBalance.amount.toBig()
             .mul(newLockDuration)
@@ -260,7 +260,7 @@ export class DefaultEscrowAPI implements EscrowAPI {
                 ),
                 apy: new Big(0)
             };
-        };
+        }
         // Reward amount for the entire time is the newUserStake / netTotalStake * blockReward * lock duration
         const rewardAmount = newUserStake
             .div(newTotalStake)

--- a/src/parachain/replace.ts
+++ b/src/parachain/replace.ts
@@ -201,7 +201,8 @@ export class DefaultReplaceAPI implements ReplaceAPI {
             replaceRequests
                 .filter((v) => v[1].isSome.valueOf)
                 // Can be unwrapped because the filter removes `None` values
-                .map((v) => parseReplaceRequest(this.vaultsAPI, v[1].unwrap(), this.btcNetwork, this.wrappedCurrency))
+                .map(([id, req]) =>
+                    parseReplaceRequest(this.vaultsAPI, req.unwrap(), this.btcNetwork, this.wrappedCurrency, storageKeyToNthInner(id)))
         );
     }
 
@@ -214,15 +215,16 @@ export class DefaultReplaceAPI implements ReplaceAPI {
                 .filter((v) => v[1].isSome.valueOf)
                 // Can be unwrapped because the filter removes `None` values
                 .map(
-                    (v) =>
+                    ([id, req]) =>
                         new Promise<void>((resolve) => {
                             parseReplaceRequest(
                                 this.vaultsAPI,
-                                v[1].unwrap(),
+                                req.unwrap(),
                                 this.btcNetwork,
-                                this.wrappedCurrency
+                                this.wrappedCurrency,
+                                storageKeyToNthInner(id)
                             ).then((replaceRequest) => {
-                                replaceRequestMap.set(storageKeyToNthInner(v[0]), replaceRequest);
+                                replaceRequestMap.set(storageKeyToNthInner(id), replaceRequest);
                                 resolve();
                             });
                         })
@@ -237,7 +239,8 @@ export class DefaultReplaceAPI implements ReplaceAPI {
             this.vaultsAPI,
             await this.api.query.replace.replaceRequests.at(head, ensureHashEncoded(this.api, replaceId)),
             this.btcNetwork,
-            this.wrappedCurrency
+            this.wrappedCurrency,
+            replaceId
         );
     }
 
@@ -266,7 +269,7 @@ export class DefaultReplaceAPI implements ReplaceAPI {
             requestPairs.map(
                 ([id, req]) =>
                     new Promise<[H256, ReplaceRequestExt]>((resolve) => {
-                        parseReplaceRequest(this.vaultsAPI, req, this.btcNetwork, this.wrappedCurrency).then(
+                        parseReplaceRequest(this.vaultsAPI, req, this.btcNetwork, this.wrappedCurrency, id).then(
                             (replaceRequest) => {
                                 resolve([id, replaceRequest]);
                             }

--- a/src/types/requestTypes.ts
+++ b/src/types/requestTypes.ts
@@ -83,6 +83,7 @@ export interface RefundRequestExt {
 }
 
 export interface ReplaceRequestExt {
+    id: string;
     btcAddress: string;
     newVault: InterbtcPrimitivesVaultId;
     oldVault: InterbtcPrimitivesVaultId;

--- a/src/utils/encoding.ts
+++ b/src/utils/encoding.ts
@@ -226,12 +226,14 @@ export async function parseReplaceRequest(
     vaultsAPI: VaultsAPI,
     req: InterbtcPrimitivesReplaceReplaceRequest,
     network: Network,
-    wrappedCurrency: WrappedCurrency
+    wrappedCurrency: WrappedCurrency,
+    id: H256 | string
 ): Promise<ReplaceRequestExt> {
     const currencyIdLiteral = currencyIdToLiteral(req.oldVault.currencies.collateral);
     const oldVault = await vaultsAPI.get(req.oldVault.accountId, currencyIdLiteral);
     const collateralCurrency = currencyIdToMonetaryCurrency(oldVault.id.currencies.collateral) as Currency<CollateralUnit>;
     return {
+        id: stripHexPrefix(id.toString()),
         btcAddress: encodeBtcAddress(req.btcAddress, network),
         newVault: req.newVault,
         oldVault: req.oldVault,


### PR DESCRIPTION
Adds `id` to the `replaceRequestExt` type, so the UI can display it.
UI already attempts to do so (but it's undefined) so this should be a drop-in upgrade.