### PR TITLE
fix: issue griefing collateral rounding

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@interlay/interbtc-api",
-  "version": "1.8.7",
+  "version": "1.8.8",
   "description": "JavaScript library to interact with interBTC and kBTC",
   "main": "build/src/index.js",
   "typings": "build/src/index.d.ts",

--- a/src/parachain/issue.ts
+++ b/src/parachain/issue.ts
@@ -256,7 +256,7 @@ export class DefaultIssueAPI implements IssueAPI {
     ): Promise<SubmittableExtrinsic<"promise">> {
         let griefingCollateral = await this.feeAPI.getGriefingCollateral(amount, GriefingCollateralType.Issue);
         // add() here is a hacky workaround for rounding errors
-        const oneHundred = newMonetaryAmount(100, griefingCollateral.currency);
+        const oneHundred = newMonetaryAmount(500, griefingCollateral.currency);
         griefingCollateral = griefingCollateral.add(oneHundred);
         return this.api.tx.issue.requestIssue(
             amount.toString(amount.currency.rawBase),


### PR DESCRIPTION
Putting together a skeleton repo for AmsterDOT, looks like the rounding of griefing collateral still fails sometimes.