### PR TITLE
fix: correct no tokens issued check

### DIFF
--- a/src/parachain/vaults.ts
+++ b/src/parachain/vaults.ts
@@ -575,8 +575,8 @@ export class DefaultVaultsAPI implements VaultsAPI {
         );
     }
 
-    private isNoTokensIssuedError(e: Error): boolean {
-        return e.message !== undefined && e.message.includes("NoTokensIssued");
+    private isNoTokensIssuedError(e: string): boolean {
+        return e !== undefined && e.includes("No tokens issued");
     }
 
     async isBelowPremiumThreshold(vaultId: InterbtcPrimitivesVaultId): Promise<boolean> {
@@ -614,10 +614,10 @@ export class DefaultVaultsAPI implements VaultsAPI {
                 collateralization = await this.getCollateralizationFromVault(vaultId, onlyIssued);
             }
         } catch (e) {
-            if (this.isNoTokensIssuedError(e as Error)) {
+            if (this.isNoTokensIssuedError(e as string)) {
                 return Promise.resolve(undefined);
             }
-            return Promise.reject(new Error(`Error during collateralization computation: ${(e as Error).message}`));
+            return Promise.reject(new Error(`Error during collateralization computation: ${(e)}`));
         }
         if (!collateralization) {
             return Promise.resolve(undefined);


### PR DESCRIPTION
I've had to change the type from `Error` to `string` as we're not actually returning an error object (so `e.message` is always undefined).

Has been tested against a local instance of the lib, and it fixed the issue I was seeing on the UI side. 