### PR TITLE
Fix premium redeem does not filter banned vaults

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,9 +62,7 @@
     "bn.js": "4.12.0",
     "cross-fetch": "^3.0.6",
     "isomorphic-fetch": "^3.0.0",
-    "regtest-client": "^0.2.0",
-    "sinon": "^9.0.3",
-    "ts-mock-imports": "^1.3.0"
+    "regtest-client": "^0.2.0"
   },
   "devDependencies": {
     "@polkadot/typegen": "7.7.1",
@@ -85,6 +83,8 @@
     "npm-run-all": "^4.1.5",
     "nyc": "^15.1.0",
     "prettier": "^2.0.5",
+    "sinon": "^9.0.3",
+    "ts-mock-imports": "^1.3.0",
     "ts-node": "10.4.0",
     "typedoc": "^0.22.9",
     "typedoc-plugin-markdown": "^3.11.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@interlay/interbtc-api",
-  "version": "1.9.4",
+  "version": "1.10.0",
   "description": "JavaScript library to interact with interBTC and kBTC",
   "main": "build/src/index.js",
   "typings": "build/src/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@interlay/interbtc-api",
-  "version": "1.9.3",
+  "version": "1.9.4",
   "description": "JavaScript library to interact with interBTC and kBTC",
   "main": "build/src/index.js",
   "typings": "build/src/index.d.ts",

--- a/src/parachain/oracle.ts
+++ b/src/parachain/oracle.ts
@@ -77,12 +77,10 @@ export interface OracleAPI {
     ): Promise<MonetaryAmount<Currency<C>, C>>;
     /**
      * @param amount The amount of collateral tokens to convert
-     * @param collateralCurrency A `Monetary.js` object
      * @returns Converted value
      */
     convertCollateralToWrapped<C extends CurrencyUnit>(
-        amount: MonetaryAmount<Currency<C>, C>,
-        wrappedCurrency: Currency<BitcoinUnit>
+        amount: MonetaryAmount<Currency<C>, C>
     ): Promise<MonetaryAmount<Currency<BitcoinUnit>, BitcoinUnit>>;
     /**
      * @returns The period of time (in milliseconds) after an oracle's last submission

--- a/src/parachain/system.ts
+++ b/src/parachain/system.ts
@@ -25,6 +25,12 @@ export interface SystemAPI {
     subscribeToFinalizedBlockHeads(callback: (blockHeader: Header) => void): Promise<() => void>;
 
     /**
+     * On every new parachain block, call the callback function with the new block header
+     * @param callback Function to be called with every new unfinalized block header
+     */
+     subscribeToCurrentBlockHeads(callback: (blockHeader: Header) => void): Promise<() => void>;
+
+     /**
      * @returns The parachain status code object.
      */
     getStatusCode(): Promise<SecurityStatusCode>;
@@ -55,6 +61,13 @@ export class DefaultSystemAPI {
 
     async subscribeToFinalizedBlockHeads(callback: (blockHeader: Header) => void): Promise<() => void> {
         const unsub = await this.api.rpc.chain.subscribeFinalizedHeads((head) => {
+            callback(head);
+        });
+        return unsub;
+    }
+
+    async subscribeToCurrentBlockHeads(callback: (blockHeader: Header) => void): Promise<() => void> {
+        const unsub = await this.api.rpc.chain.subscribeAllHeads((head) => {
             callback(head);
         });
         return unsub;

--- a/src/parachain/vaults.ts
+++ b/src/parachain/vaults.ts
@@ -788,9 +788,7 @@ export class DefaultVaultsAPI implements VaultsAPI {
         
         const premiumRedeemVaultPredicates = await Promise.all(
             redeemVaults
-                .map((vault) => this.isBelowPremiumThreshold(vault.id)
-                    });
-                })
+                .map((vault) => this.isBelowPremiumThreshold(vault.id))
         );
         redeemVaults
             .filter((_, index) => premiumRedeemVaultPredicates[index])
@@ -832,8 +830,6 @@ export class DefaultVaultsAPI implements VaultsAPI {
         ]);
         vaults
             .filter((vault) => this.isVaultEligibleForRedeem(vault, activeBlockNumber))
-                return this.isVaultEligibleForRedeem(vault, activeBlockNumber);
-            })
             .sort((vault1, vault2) => {
                 // Descending order
                 const vault1Redeemable = vault1.getRedeemableTokens().toBig();

--- a/src/parachain/vaults.ts
+++ b/src/parachain/vaults.ts
@@ -833,7 +833,7 @@ export class DefaultVaultsAPI implements VaultsAPI {
             this.systemAPI.getCurrentActiveBlockNumber(),
         ]);
         vaults
-            .filter((vault) => {
+            .filter((vault) => this.isVaultEligibleForRedeem(vault, activeBlockNumber))
                 return this.isVaultEligibleForRedeem(vault, activeBlockNumber);
             })
             .sort((vault1, vault2) => {

--- a/src/parachain/vaults.ts
+++ b/src/parachain/vaults.ts
@@ -491,10 +491,7 @@ export class DefaultVaultsAPI implements VaultsAPI {
         const globalRewardShare = vaultStake.toBig().div(globalStake.toBig());
         const vaultRewardPerBlock = globalRewardPerBlock.mul(globalRewardShare);
         const ownRewardPerBlock = vaultRewardPerBlock.mul(vaultRewardShare);
-        const rewardAsWrapped = await this.oracleAPI.convertCollateralToWrapped(
-            ownRewardPerBlock,
-            this.wrappedCurrency
-        );
+        const rewardAsWrapped = await this.oracleAPI.convertCollateralToWrapped(ownRewardPerBlock);
         const blockTime = minimumBlockPeriod.toNumber() * 2; // ms
         const blocksPerYear = (86400 * 365 * 1000) / blockTime;
         const annualisedReward = rewardAsWrapped.mul(blocksPerYear);
@@ -643,10 +640,7 @@ export class DefaultVaultsAPI implements VaultsAPI {
         if (issuedTokens.isZero()) {
             return Promise.reject("No tokens issued");
         }
-        const collateralInWrapped = await this.oracleAPI.convertCollateralToWrapped(
-            newCollateral,
-            currencyIdToMonetaryCurrency(vaultId.currencies.wrapped)
-        );
+        const collateralInWrapped = await this.oracleAPI.convertCollateralToWrapped(newCollateral);
         return collateralInWrapped.toBig().div(issuedTokens.toBig());
     }
 

--- a/src/parachain/vaults.ts
+++ b/src/parachain/vaults.ts
@@ -788,9 +788,7 @@ export class DefaultVaultsAPI implements VaultsAPI {
         
         const premiumRedeemVaultPredicates = await Promise.all(
             redeemVaults
-                .map((vault) => {
-                    return new Promise((resolve, reject) => {
-                        this.isBelowPremiumThreshold(vault.id).then(resolve).catch(reject);
+                .map((vault) => this.isBelowPremiumThreshold(vault.id)
                     });
                 })
         );

--- a/src/types/vault.ts
+++ b/src/types/vault.ts
@@ -73,10 +73,7 @@ export class VaultExt<WrappedUnit extends BitcoinUnit> {
         }
         const freeCollateral = await this.getFreeCollateral();
         const secureCollateralThreshold = await this.getSecureCollateralThreshold();
-        const backableWrappedTokens = await this.oracleAPI.convertCollateralToWrapped(
-            freeCollateral,
-            currencyIdToMonetaryCurrency(this.id.currencies.wrapped)
-        );
+        const backableWrappedTokens = await this.oracleAPI.convertCollateralToWrapped(freeCollateral);
         // Force type-assert here as the oracle API only uses wrapped Bitcoin
         return backableWrappedTokens.div(secureCollateralThreshold) as unknown as MonetaryAmount<
             Currency<WrappedUnit>,

--- a/test/integration/parachain/staging/sequential/vaults.test.ts
+++ b/test/integration/parachain/staging/sequential/vaults.test.ts
@@ -2,14 +2,40 @@ import { ApiPromise, Keyring } from "@polkadot/api";
 import { KeyringPair } from "@polkadot/keyring/types";
 import { Bitcoin, BitcoinUnit, ExchangeRate, Currency } from "@interlay/monetary-js";
 import Big from "big.js";
-import { DefaultInterBtcApi, InterBtcApi, InterbtcPrimitivesVaultId, WrappedIdLiteral, currencyIdToMonetaryCurrency, CollateralUnit, CollateralCurrency, tickerToCurrencyIdLiteral, GovernanceUnit, GovernanceIdLiteral } from "../../../../../src/index";
+import { 
+    DefaultInterBtcApi, 
+    InterBtcApi, 
+    InterbtcPrimitivesVaultId, 
+    WrappedIdLiteral, 
+    currencyIdToMonetaryCurrency, 
+    CollateralUnit, 
+    CollateralCurrency, 
+    tickerToCurrencyIdLiteral, 
+    GovernanceUnit, 
+    GovernanceIdLiteral
+} from "../../../../../src/index";
 
 import { createSubstrateAPI } from "../../../../../src/factory";
 import { assert } from "../../../../chai";
-import { ORACLE_URI, VAULT_1_URI, VAULT_2_URI, BITCOIN_CORE_HOST, BITCOIN_CORE_NETWORK, BITCOIN_CORE_PASSWORD, BITCOIN_CORE_PORT, BITCOIN_CORE_USERNAME, BITCOIN_CORE_WALLET, PARACHAIN_ENDPOINT, VAULT_3_URI, VAULT_TO_LIQUIDATE_URI, VAULT_TO_BAN_URI, ESPLORA_BASE_PATH } from "../../../../config";
+import { 
+    ORACLE_URI, 
+    VAULT_1_URI, 
+    VAULT_2_URI, 
+    BITCOIN_CORE_HOST, 
+    BITCOIN_CORE_NETWORK, 
+    BITCOIN_CORE_PASSWORD, 
+    BITCOIN_CORE_PORT, 
+    BITCOIN_CORE_USERNAME, 
+    BITCOIN_CORE_WALLET, 
+    PARACHAIN_ENDPOINT, 
+    VAULT_3_URI, 
+    VAULT_TO_LIQUIDATE_URI, 
+    VAULT_TO_BAN_URI, 
+    ESPLORA_BASE_PATH 
+} from "../../../../config";
 import { BitcoinCoreClient, newAccountId, WrappedCurrency, newVaultId, currencyIdToLiteral, CollateralIdLiteral } from "../../../../../src";
 import { encodeVaultId, getCorrespondingCollateralCurrency, issueSingle, newMonetaryAmount } from "../../../../../src/utils";
-import { callWithExchangeRate } from "../../../../utils/helpers";
+import sinon from "sinon";
 
 describe("vaultsAPI", () => {
     let oracleAccount: KeyringPair;
@@ -62,6 +88,10 @@ describe("vaultsAPI", () => {
 
     after(() => {
         return api.disconnect();
+    });
+
+    afterEach(() => {
+        sinon.reset();
     });
 
     function vaultIsATestVault(vaultAddress: string): boolean {
@@ -132,7 +162,7 @@ describe("vaultsAPI", () => {
         }
     });
 
-    it.skip("should getPremiumRedeemVaults after a price crash", async () => {
+    it("should getPremiumRedeemVaults after a price crash", async () => {
         const collateralCurrencyIdLiteral = currencyIdToLiteral(vault_3_id.currencies.collateral) as CollateralIdLiteral;
         const vault = await interBtcAPI.vaults.get(vault_3_id.accountId, collateralCurrencyIdLiteral);
         let issuableAmount = await vault.getIssuableTokens();
@@ -157,29 +187,38 @@ describe("vaultsAPI", () => {
         const initialExchangeRate = await interBtcAPI.oracle.getExchangeRate(collateralCurrencyTyped);
         // crash the exchange rate so that the vault falls below the premium redeem threshold
         const exchangeRateValue = initialExchangeRate.toBig().div(modifyExchangeRateBy);
-        const exchangeRateToSet = new ExchangeRate<
+        const mockExchangeRate = new ExchangeRate<
             Bitcoin,
             BitcoinUnit,
             typeof collateralCurrencyTyped,
             typeof collateralCurrencyTyped.units
         >(Bitcoin, collateralCurrencyTyped, exchangeRateValue);
 
-        await callWithExchangeRate(oracleInterBtcAPI.oracle, exchangeRateToSet, async () => {
-            const premiumRedeemVaults = await interBtcAPI.vaults.getPremiumRedeemVaults();
-            assert.equal(premiumRedeemVaults.size, 1);
-            assert.equal(
-                encodeVaultId(premiumRedeemVaults.keys().next().value),
-                encodeVaultId(vault_3_id),
-                "Premium redeem vault is not the expected one"
-            );
+        // stub the oracle API to always return the new exchange rate
+        const stub = sinon.stub(interBtcAPI.oracle, "getExchangeRate")
+            .withArgs(sinon.match.any)
+            .returns(Promise.resolve(mockExchangeRate as any)); // "as any" to help eslint play nicely
 
-            const premiumRedeemAmount = premiumRedeemVaults.values().next().value;
-            assert.isTrue(
-                premiumRedeemAmount.gte(issuableAmount),
-                "Amount available for premium redeem should be higher"
-            );
-        });
-    });
+        const premiumRedeemVaults = await interBtcAPI.vaults.getPremiumRedeemVaults();
+
+        // Check that the stub has indeed been called at least once 
+        // If not, code has changed and our assumptions when mocking the oracle API are no longer valid
+        sinon.assert.called(stub);
+
+        // real assertions here
+        assert.equal(premiumRedeemVaults.size, 1);
+        assert.equal(
+            encodeVaultId(premiumRedeemVaults.keys().next().value),
+            encodeVaultId(vault_3_id),
+            "Premium redeem vault is not the expected one"
+        );
+
+        const premiumRedeemAmount = premiumRedeemVaults.values().next().value;
+        assert.isTrue(
+            premiumRedeemAmount.gte(issuableAmount),
+            "Amount available for premium redeem should be higher"
+        );
+    }).timeout(5 * 60000);
 
     it("should getLiquidationCollateralThreshold", async () => {
         const threshold = await interBtcAPI.vaults.getLiquidationCollateralThreshold(collateralCurrency);

--- a/test/integration/parachain/staging/sequential/vaults.test.ts
+++ b/test/integration/parachain/staging/sequential/vaults.test.ts
@@ -91,7 +91,8 @@ describe("vaultsAPI", () => {
     });
 
     afterEach(() => {
-        sinon.reset();
+        // discard any stubbed methods after each test
+        sinon.restore();
     });
 
     function vaultIsATestVault(vaultAddress: string): boolean {
@@ -168,7 +169,6 @@ describe("vaultsAPI", () => {
         let issuableAmount = await vault.getIssuableTokens();
         // TODO: Look into why requesting the full issuable amount fails, and remove the line below
         issuableAmount = issuableAmount.mul(0.9);
-        console.log(`issuableAmount: ${issuableAmount.toString()}`);
         await issueSingle(interBtcAPI, bitcoinCoreClient, oracleAccount, issuableAmount, vault_3_id);
 
         const currentVaultCollateralization =


### PR DESCRIPTION
Three basic changes:
 - getVaultsWithRedeemableTokens now also includes vaults with status "inactive" as well as "active" (ie. only excludes statuses "liquidated" or "committed theft")
 - getPremiumRedeemVaults now applies the same restrictions as getVaultsWithRedeemableTokens as well as the vault's collateral needing to be below the premium redeem threshold.
 - extracted shared method to check if vault is active or inactive, and has redeemable tokens.