### PR TITLE
Peter/remove account

### DIFF
--- a/src/interbtc-api.ts
+++ b/src/interbtc-api.ts
@@ -56,6 +56,7 @@ export interface InterBtcApi {
     readonly rewards: RewardsAPI;
     readonly escrow: EscrowAPI;
     setAccount(account: AddressOrPair, signer?: Signer): void;
+    removeAccount(): void;
     readonly account: AddressOrPair | undefined;
     getGovernanceCurrency(): Currency<GovernanceUnit>;
     getWrappedCurrency(): Currency<BitcoinUnit>;
@@ -163,6 +164,10 @@ export class DefaultInterBtcApi implements InterBtcApi {
             this.api.setSigner(signer);
         }
         this.transactionAPI.setAccount(account);
+    }
+
+    removeAccount(): void {
+        this.transactionAPI.removeAccount();
     }
 
     get account(): AddressOrPair | undefined {

--- a/src/parachain/transaction.ts
+++ b/src/parachain/transaction.ts
@@ -9,6 +9,7 @@ import { ACCOUNT_NOT_SET_ERROR_MESSAGE, IGNORED_ERROR_MESSAGES } from "../utils/
 
 export interface TransactionAPI {
     setAccount(account: AddressOrPair): void;
+    removeAccount(): void;
     getAccount(): AddressOrPair | undefined;
     sendLogged<T extends AnyTuple>(
         transaction: SubmittableExtrinsic<"promise">,
@@ -22,6 +23,10 @@ export class DefaultTransactionAPI {
 
     public setAccount(account: AddressOrPair): void {
         this.account = account;
+    }
+
+    public removeAccount(): void {
+        this.account = undefined;
     }
 
     public getAccount(): AddressOrPair | undefined {

--- a/test/integration/parachain/staging/interbtc-api.test.ts
+++ b/test/integration/parachain/staging/interbtc-api.test.ts
@@ -1,14 +1,13 @@
 import { ApiPromise, Keyring } from "@polkadot/api";
-import { Polkadot } from "@interlay/monetary-js";
 
 import { assert } from "../../../chai";
 import { createAPIRegistry, createSubstrateAPI, DefaultInterBtcApi, InterBtcApi, newMonetaryAmount } from "../../../../src";
 import { SingleAccountSigner } from "../../../utils/SingleAccountSigner";
-import { PARACHAIN_ENDPOINT } from "../../../config";
+import { ORACLE_URI, PARACHAIN_ENDPOINT } from "../../../config";
 
 describe("InterBtcApi", () => {
     const keyring = new Keyring();
-    const keyringPair = keyring.addFromUri("//Bob");
+    const keyringPair = keyring.addFromUri(ORACLE_URI);
     let interBTC: InterBtcApi;
     const registry = createAPIRegistry();
     let api: ApiPromise;
@@ -51,7 +50,8 @@ describe("InterBtcApi", () => {
             interBTC.setAccount(keyringPair);
             interBTC.removeAccount();
 
-            const amount = newMonetaryAmount(1, Polkadot, true);
+            const governanceCurrency = interBTC.getGovernanceCurrency();
+            const amount = newMonetaryAmount(1, governanceCurrency, true);
             const aliceAddress = keyring.addFromUri("//Alice").address;
             const tx = interBTC.tokens.transfer(aliceAddress, amount);
             // Transfer to Alice should be rejected, since Bob's account was removed.


### PR DESCRIPTION
Adding option to remove linked account from the lib (to allow disconnecting account from the dApp UI). After the account is removed, it is no longer possible to make transactions.