### PR TITLE
feat: improved hrmp channel opening script

### DIFF
--- a/scripts/hrmp-setup.ts
+++ b/scripts/hrmp-setup.ts
@@ -154,29 +154,32 @@ function printExtrinsic(name: string, extrinsic: SubmittableExtrinsic<"promise">
 async function maybeSubmitProposal(name: string, extrinsic: SubmittableExtrinsic<"promise">, endpoint: string, api: ApiPromise, shouldSubmit: boolean) {
     printExtrinsic(name, extrinsic, endpoint);
 
-    console.log("Please check the printed extrinsic and enter the seed phrase to submit the proposal.");
-    if (shouldSubmit) {
-        let rl = readline.createInterface({
-            input: process.stdin,
-            output: process.stdout
-        });
-        const it = rl[Symbol.asyncIterator]();
-        const seed = await it.next();
-
-        // construct the proposal
-        const deposit = api.consts.democracy.minimumDeposit.toNumber();
-        const preImageSubmission = api.tx.democracy.notePreimage(extrinsic.method.toHex());
-        const proposal = api.tx.democracy.propose(extrinsic.method.hash.toHex(), deposit);
-        const batched = api.tx.utility.batchAll([preImageSubmission, proposal]);
-
-        console.log("Submitting proposal...");
-        const keyring = new Keyring({ type: "sr25519" });
-        const userKeyring = keyring.addFromUri(seed.value);
-        const transactionAPI = new DefaultTransactionAPI(api, userKeyring);
-        await transactionAPI.sendLogged(batched, undefined);
-
-        rl.close();
+    if (!shouldSubmit) {
+        return;
     }
+
+    console.log("Please check the printed extrinsic and enter the seed phrase to submit the proposal.");
+
+    let rl = readline.createInterface({
+        input: process.stdin,
+        output: process.stdout
+    });
+    const it = rl[Symbol.asyncIterator]();
+    const seed = await it.next();
+
+    // construct the proposal
+    const deposit = api.consts.democracy.minimumDeposit.toNumber();
+    const preImageSubmission = api.tx.democracy.notePreimage(extrinsic.method.toHex());
+    const proposal = api.tx.democracy.propose(extrinsic.method.hash.toHex(), deposit);
+    const batched = api.tx.utility.batchAll([preImageSubmission, proposal]);
+
+    console.log("Submitting proposal...");
+    const keyring = new Keyring({ type: "sr25519" });
+    const userKeyring = keyring.addFromUri(seed.value);
+    const transactionAPI = new DefaultTransactionAPI(api, userKeyring);
+    await transactionAPI.sendLogged(batched, undefined);
+
+    rl.close();
 }
 
 async function main(): Promise<void> {


### PR DESCRIPTION
Now you only need to modify the consts in the top of the script when using the script for opening new channels. Also you don't have to manually encode relay calls anymore - it's now embedded in this script.

Edit: I also made everything configurable by cli arguments, and added the option to automatically submit a governance proposal with the generated extrinsic.

Example usage: `yarn hrmp-setup --action batched --destination-parachain-id 2085 --refund-hex-address 0xa2e1685f62b2a1a996a2a1ba10ac6836c2b72174cab1bd1c6907454e6365fb70 --submit-proposal`