### PR TITLE
fix: reject promise if no issued tokens

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@interlay/interbtc-api",
-  "version": "1.10.3",
+  "version": "1.10.4",
   "description": "JavaScript library to interact with interBTC and kBTC",
   "main": "build/src/index.js",
   "typings": "build/src/index.d.ts",

--- a/src/parachain/vaults.ts
+++ b/src/parachain/vaults.ts
@@ -685,7 +685,7 @@ export class DefaultVaultsAPI implements VaultsAPI {
 
     async getTotalIssuedAmount(): Promise<MonetaryAmount<WrappedCurrency, BitcoinUnit>> {
         const issuedTokens = await this.tokensAPI.total(this.wrappedCurrency);
-        return issuedTokens;
+        return issuedTokens.toBig().eq(0) ? Promise.reject(new Error("No issued kBTC")) : issuedTokens;
     }
 
     async getTotalIssuableAmount(): Promise<MonetaryAmount<WrappedCurrency, BitcoinUnit>> {

--- a/src/parachain/vaults.ts
+++ b/src/parachain/vaults.ts
@@ -494,6 +494,11 @@ export class DefaultVaultsAPI implements VaultsAPI {
                 ).reserved,
                 this.api.consts.timestamp.minimumPeriod,
             ]);
+
+        if (globalStake.toBig().eq(0)) {
+            return Promise.reject(new Error("No issued kBTC"));
+        }
+
         const globalRewardShare = vaultStake.toBig().div(globalStake.toBig());
         const vaultRewardPerBlock = globalRewardPerBlock.mul(globalRewardShare);
         const ownRewardPerBlock = vaultRewardPerBlock.mul(vaultRewardShare);
@@ -685,7 +690,7 @@ export class DefaultVaultsAPI implements VaultsAPI {
 
     async getTotalIssuedAmount(): Promise<MonetaryAmount<WrappedCurrency, BitcoinUnit>> {
         const issuedTokens = await this.tokensAPI.total(this.wrappedCurrency);
-        return issuedTokens.toBig().eq(0) ? Promise.reject(new Error("No issued kBTC")) : issuedTokens;
+        return issuedTokens;
     }
 
     async getTotalIssuableAmount(): Promise<MonetaryAmount<WrappedCurrency, BitcoinUnit>> {


### PR DESCRIPTION
`getBlockRewardAPY` function returns rejected promise when `globalStake` is zero. 

~@bvotteler could you take a look at this? Don't know if this is the best way to handle it. There's a bug when we have zero issued tokens (at https://github.com/interlay/interbtc-api/blob/master/src/parachain/vaults.ts#L497).~

~Dan mentioned that the fix here is to reject the promise - don't know if this is the correct place to reject it though, or if we should be handling this in the `getBlockRewardAPY` function rather than higher up.~