### PR TITLE
Expose total staked governing currency amount (eg. total staked KINT)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@interlay/interbtc-api",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "description": "JavaScript library to interact with interBTC and kBTC",
   "main": "build/src/index.js",
   "typings": "build/src/index.d.ts",


### PR DESCRIPTION
_Draft, not ready for review yet_

Expose new API to get total staked governing currency amount via `EscrowAPI.getTotalStakedBalance()`.