### PR TITLE
fix: div by zero error for liquidated vault

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@interlay/interbtc-api",
-  "version": "1.11.1",
+  "version": "1.11.2",
   "description": "JavaScript library to interact with interBTC and kBTC",
   "main": "build/src/index.js",
   "typings": "build/src/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@interlay/interbtc-api",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "description": "JavaScript library to interact with interBTC and kBTC",
   "main": "build/src/index.js",
   "typings": "build/src/index.d.ts",

--- a/src/parachain/escrow.ts
+++ b/src/parachain/escrow.ts
@@ -224,8 +224,7 @@ export class DefaultEscrowAPI implements EscrowAPI {
         const rawStakedBalances = await this.api.query.escrow.locked.entries();
 
         const totalCurrentAmount = rawStakedBalances
-            .filter(([_, escrowLockedBalance]) => escrowLockedBalance.end.toBn().gt(height))
-            .reduce((acc, [_, escrowLockedBalance]) => acc.add(escrowLockedBalance.amount), new BN(0));
+            .reduce((acc, [_, escrowLockedBalance]) => acc.add(escrowLockedBalance.amount.toBn()), new BN(0));
 
         return newMonetaryAmount(totalCurrentAmount.toNumber(), this.governanceCurrency as Currency<GovernanceUnit>);
     }

--- a/src/parachain/vaults.ts
+++ b/src/parachain/vaults.ts
@@ -462,12 +462,7 @@ export class DefaultVaultsAPI implements VaultsAPI {
         collateralCurrencyIdLiteral: CollateralIdLiteral
     ): Promise<Big> {
         const vault = await this.get(vaultAccountId, collateralCurrencyIdLiteral);
-
-        const backingCollateral = vault.backingCollateral.toBig();
-        if (backingCollateral.eq(0)) {
-            return Promise.reject(new Error("No backing collateral"));
-        }
-
+        
         const collateralCurrency = currencyIdLiteralToMonetaryCurrency(
             this.api,
             collateralCurrencyIdLiteral
@@ -476,6 +471,18 @@ export class DefaultVaultsAPI implements VaultsAPI {
             newVaultId(this.api, vaultAccountId.toString(), collateralCurrency, this.wrappedCurrency),
             nominatorId
         );
+
+        // short-circuit a potential 0 div 0 scenario where 
+        // the nominator is equal to the vault and has zero collateral
+        if (nominatorCollateral.isZero()) {
+            return nominatorCollateral.toBig();
+        }
+
+        const backingCollateral = vault.backingCollateral.toBig();
+        if (backingCollateral.eq(0)) {
+            return Promise.reject(new Error("No backing collateral"));
+        }
+
         return nominatorCollateral.toBig().div(backingCollateral);
     }
 

--- a/src/parachain/vaults.ts
+++ b/src/parachain/vaults.ts
@@ -462,6 +462,12 @@ export class DefaultVaultsAPI implements VaultsAPI {
         collateralCurrencyIdLiteral: CollateralIdLiteral
     ): Promise<Big> {
         const vault = await this.get(vaultAccountId, collateralCurrencyIdLiteral);
+
+        const backingCollateral = vault.backingCollateral.toBig();
+        if (backingCollateral.eq(0)) {
+            return Promise.reject(new Error("No backing collateral"));
+        }
+
         const collateralCurrency = currencyIdLiteralToMonetaryCurrency(
             this.api,
             collateralCurrencyIdLiteral
@@ -470,7 +476,7 @@ export class DefaultVaultsAPI implements VaultsAPI {
             newVaultId(this.api, vaultAccountId.toString(), collateralCurrency, this.wrappedCurrency),
             nominatorId
         );
-        return nominatorCollateral.toBig().div(vault.backingCollateral.toBig());
+        return nominatorCollateral.toBig().div(backingCollateral);
     }
 
     async getBlockRewardAPY(

--- a/test/integration/parachain/release/redeem.test.ts
+++ b/test/integration/parachain/release/redeem.test.ts
@@ -113,8 +113,9 @@ describe("redeem", () => {
             // There should be no burnable tokens
             await expect(userInterBtcAPI.redeem.getBurnExchangeRate(collateralCurrency as Currency<CollateralUnit>)).to.be.rejected;
 
-            // issue a small amount of tokens (dust amount)
-            const issuedTokens = await userInterBtcAPI.issue.getDustValue();
+            // issue a small amount of tokens (10x dust)
+            const dustValue = await userInterBtcAPI.issue.getDustValue();
+            const issuedTokens = dustValue.mul(10);
             await issueSingle(userInterBtcAPI, userBitcoinCoreClient, userAccount, issuedTokens, vaultToLiquidateId, true, false);
             const vaultBitcoinCoreClient = new BitcoinCoreClient(
                 BITCOIN_CORE_NETWORK,
@@ -127,7 +128,7 @@ describe("redeem", () => {
 
             // Steal some bitcoin (spend from the vault's account)
             const foreignBitcoinAddress = "bcrt1qefxeckts7tkgz7uach9dnwer4qz5nyehl4sjcc";
-            const amountToSteal = issuedTokens;
+            const amountToSteal = dustValue;
             const {txid: btcTxId} = await vaultBitcoinCoreClient.sendBtcTxAndMine(foreignBitcoinAddress, amountToSteal, 3);
             // wait for tx inclusion and block finalization.
             await waitForBlockFinalization(bitcoinCoreClient, userInterBtcAPI.btcRelay);

--- a/test/integration/parachain/release/redeem.test.ts
+++ b/test/integration/parachain/release/redeem.test.ts
@@ -40,8 +40,7 @@ import {
     WrappedCurrency 
 } from "../../../../src";
 import { assert, expect } from "../../../chai";
-import { callWith, runWhileMiningBTCBlocks, sudo } from "../../../utils/helpers";
-import Big from "big.js";
+import { runWhileMiningBTCBlocks, sudo } from "../../../utils/helpers";
 
 export type RequestResult = { hash: Hash; vault: VaultRegistryVault };
 

--- a/test/integration/parachain/staging/setup/initialize.test.ts
+++ b/test/integration/parachain/staging/setup/initialize.test.ts
@@ -147,7 +147,7 @@ describe("Initialize parachain state", () => {
         assert.equal(stableParachainConfirmationsToSet, stableParachainConfirmations, "Setting the Parachain confirmations failed");
     });
 
-    it("should set the exchange rate", async () => {
+    it.skip("should set the exchange rate", async () => {
         async function setCollateralExchangeRate<C extends CollateralUnit>(value: Big, currency: Currency<C>) {
             const exchangeRate = new ExchangeRate<Bitcoin, BitcoinUnit, typeof currency, typeof currency.units>(Bitcoin, currency, value);
             // result will be medianized

--- a/test/integration/parachain/staging/setup/initialize.test.ts
+++ b/test/integration/parachain/staging/setup/initialize.test.ts
@@ -147,7 +147,7 @@ describe("Initialize parachain state", () => {
         assert.equal(stableParachainConfirmationsToSet, stableParachainConfirmations, "Setting the Parachain confirmations failed");
     });
 
-    it.skip("should set the exchange rate", async () => {
+    it("should set the exchange rate", async () => {
         async function setCollateralExchangeRate<C extends CollateralUnit>(value: Big, currency: Currency<C>) {
             const exchangeRate = new ExchangeRate<Bitcoin, BitcoinUnit, typeof currency, typeof currency.units>(Bitcoin, currency, value);
             // result will be medianized

--- a/test/unit/vaults.test.ts
+++ b/test/unit/vaults.test.ts
@@ -1,0 +1,166 @@
+import { assert, expect } from "../chai";
+import Big, { BigSource } from "big.js";
+import sinon from "sinon";
+import { 
+    CollateralCurrency,
+    CurrencyIdLiteral,
+    CurrencyUnit,
+    DefaultRewardsAPI,
+    DefaultVaultsAPI,
+    InterbtcPrimitivesVaultId,
+    newMonetaryAmount,
+    VaultExt 
+} from "../../src";
+import * as allThingsCurrency from "../../src/types/currency";
+import * as allThingsEncoding from "../../src/utils/encoding";
+import { AccountId } from "@polkadot/types/interfaces";
+import { BitcoinUnit, Currency, Kusama } from "@interlay/monetary-js";
+
+describe("DefaultVaultsAPI", () => {
+    let vaultsApi: DefaultVaultsAPI;
+    const testCollCcyId: CurrencyIdLiteral = CurrencyIdLiteral.KSM;
+    const testCollateralCurrency: CollateralCurrency = Kusama;
+
+    let fakeRewardsApi: sinon.SinonStubbedInstance<DefaultRewardsAPI>;
+
+    beforeEach(() => {
+        // only mock/stub what we really need
+        fakeRewardsApi = sinon.createStubInstance(DefaultRewardsAPI);
+        vaultsApi = new DefaultVaultsAPI(
+            undefined as any,
+            undefined as any,
+            undefined as any,
+            undefined as any,
+            undefined as any,
+            undefined as any,
+            undefined as any,
+            undefined as any,
+            fakeRewardsApi,
+            undefined as any,
+            undefined as any
+        );
+    });
+
+    afterEach(() => {
+        sinon.restore();
+        sinon.reset();
+    });
+
+    describe("backingCollateralProportion", () => {
+        /* ===== Helper methods for mocking methods used in this particular method ===== */
+        const prepareAllMocks = (
+            nominatorAccountName: string,
+            vaultAccountName: string,
+            nominatorCollateralStakedAmount: Big,
+            vaultBackingCollateralAmount: Big,
+            collateralCurrency: CollateralCurrency
+        ) => {
+            const nominatorId = createFakeAccountId(nominatorAccountName);
+            const vaultId = createFakeAccountId(vaultAccountName);
+
+            // prepare mocks
+            const fakeVault = createFakeVaultWithBacking(vaultBackingCollateralAmount, collateralCurrency);
+            mockGetVaultMethod(fakeVault);
+            mockComputeCollateralInStakingPoolMethod(nominatorCollateralStakedAmount, collateralCurrency as any);
+            mockCurrencyIdLiteralToMonetaryCurrency(collateralCurrency);
+
+            return {
+                nominatorId,
+                vaultId
+            };
+        };
+
+        const createFakeAccountId = (someIdentifier: string): AccountId => {
+            return <AccountId>{
+                toString: () => someIdentifier,
+                toHuman: () => toString(),
+                toRawType: ()=> "FakeAccountId",
+                eq: (other?: AccountId) => !!other && toString() === other.toString(),
+            };
+        };
+
+        const mockComputeCollateralInStakingPoolMethod = <U extends CurrencyUnit>(
+            amount: BigSource,
+            currency: Currency<U>
+        ): void => {
+            const tempId = <InterbtcPrimitivesVaultId>{};
+            sinon.stub(allThingsEncoding, "newVaultId").returns(tempId);
+            fakeRewardsApi.computeCollateralInStakingPool
+                .resolves(newMonetaryAmount(amount, currency) as any);
+
+        };
+
+        const createFakeVaultWithBacking = (amount: BigSource, collateralCurrency: CollateralCurrency): VaultExt<BitcoinUnit> => {
+            // VaultExt-ish; only need .backingCollateral to be available for this test
+            return {
+                backingCollateral: newMonetaryAmount(amount, collateralCurrency as any),
+            } as any;
+        };
+
+        const mockGetVaultMethod = (mockVault: VaultExt<BitcoinUnit>): void => {
+            // make VaultAPI.get() return a mocked vault
+            sinon.stub(vaultsApi, "get").returns(Promise.resolve(mockVault));
+        };
+
+        const mockCurrencyIdLiteralToMonetaryCurrency = (returnCurrency: CollateralCurrency) => {
+            sinon.stub(allThingsCurrency, "currencyIdLiteralToMonetaryCurrency").returns(returnCurrency as any);
+        };
+        /* ===== End: Helper methods for mocking ===== */
+
+        it("should return 0 if nominator and vault have zero collateral", async () => {
+            // prepare mocks
+            const {
+                nominatorId,
+                vaultId
+            } = prepareAllMocks("nominator", "vault", new Big(0), new Big(0), testCollateralCurrency);
+
+            // do the thing
+            const proportion = await vaultsApi.backingCollateralProportion(vaultId, nominatorId, testCollCcyId);
+
+            // check result
+            const expectedProportion = new Big(0);
+            assert.equal(
+                proportion.toString(), 
+                expectedProportion.toString(),
+                `Expected actual proportion to be ${expectedProportion.toString()} but it was ${proportion.toString()}`
+            );
+        });
+
+        it("should reject if nominator has collateral, but vault has zero collateral", async () => {
+            // prepare mocks
+            const nominatorAmount = new Big(1);
+            const vaultAmount = new Big(0);
+            const {
+                nominatorId,
+                vaultId
+            } = prepareAllMocks("nominator", "vault", nominatorAmount, vaultAmount, testCollateralCurrency);
+            
+            // do & check
+            const proportionPromise = vaultsApi.backingCollateralProportion(vaultId, nominatorId, testCollCcyId);
+            expect(proportionPromise).to.be.rejectedWith(Error);
+        });
+
+        it("should calculate expected proportion", async () => {
+            // prepare mocks
+            const nominatorAmount = new Big(1);
+            const vaultAmount = new Big(2);
+            const {
+                nominatorId,
+                vaultId
+            } = prepareAllMocks("nominator", "vault", nominatorAmount, vaultAmount, testCollateralCurrency);
+            
+            // do the thing
+            const proportion = await vaultsApi.backingCollateralProportion(vaultId, nominatorId, testCollCcyId);
+            
+            // check result
+            const expectedProportion = nominatorAmount.div(vaultAmount);
+            assert.equal(
+                proportion.toString(), 
+                expectedProportion.toString(),
+                `Expected actual proportion to be ${expectedProportion.toString()} but it was ${proportion.toString()}`
+            );
+        });
+
+    });
+
+});


### PR DESCRIPTION
Fixing div by zero error for specific case when both nominator and vault have 0 (staked) collateral.
In that event, calculating backingCollateralProportion will return 0.

If however, the nominator has staked collateral, but the vault does not, now will reject with a more meaningful error.