### PR TITLE
Fix test flakiness caused by oracle

### DIFF
--- a/scripts/docker-setup.sh
+++ b/scripts/docker-setup.sh
@@ -2,7 +2,7 @@
 if ! [ -d "local-setup" ]
 then
     git clone https://github.com/interlay/parachain-launch/
-    cd parachain-launch && yarn install
+    cd parachain-launch && git checkout 1.1.0-20220613 && yarn install
     yarn start generate --config=configs/kintsugi.yml --servicesPath=configs/kintsugi-services.yml --yes --output=local-setup
     mv local-setup ../
     cd ../

--- a/test/integration/parachain/staging/sequential/oracle.test.ts
+++ b/test/integration/parachain/staging/sequential/oracle.test.ts
@@ -29,7 +29,7 @@ describe("OracleAPI", () => {
 
     it("should set exchange rate", async () => {
         for (const collateralCurrency of collateralCurrencies) {
-            const exchangeRateValue = getExchangeRateValueToSetForTesting(collateralCurrency as CollateralCurrency);
+            const exchangeRateValue = getExchangeRateValueToSetForTesting(collateralCurrency);
             const newExchangeRate = new ExchangeRate<
                 Bitcoin,
                 BitcoinUnit,

--- a/test/integration/parachain/staging/sequential/oracle.test.ts
+++ b/test/integration/parachain/staging/sequential/oracle.test.ts
@@ -6,7 +6,8 @@ import Big from "big.js";
 import { createSubstrateAPI } from "../../../../../src/factory";
 import { assert } from "../../../../chai";
 import { ESPLORA_BASE_PATH, ORACLE_URI, PARACHAIN_ENDPOINT } from "../../../../config";
-import { CollateralUnit, DefaultInterBtcApi, getCorrespondingCollateralCurrencies, InterBtcApi } from "../../../../../src";
+import { CollateralCurrency, CollateralUnit, DefaultInterBtcApi, getCorrespondingCollateralCurrencies, InterBtcApi } from "../../../../../src";
+import { getExchangeRateValueToSetForTesting } from "../../../../utils/helpers";
 
 describe("OracleAPI", () => {
     let api: ApiPromise;
@@ -28,7 +29,7 @@ describe("OracleAPI", () => {
 
     it("should set exchange rate", async () => {
         for (const collateralCurrency of collateralCurrencies) {
-            const exchangeRateValue = new Big("3913.7424920372646687827621");
+            const exchangeRateValue = getExchangeRateValueToSetForTesting(collateralCurrency as CollateralCurrency);
             const newExchangeRate = new ExchangeRate<
                 Bitcoin,
                 BitcoinUnit,

--- a/test/integration/parachain/staging/setup/initialize.test.ts
+++ b/test/integration/parachain/staging/setup/initialize.test.ts
@@ -41,7 +41,7 @@ import {
     USER_1_URI,
     ESPLORA_BASE_PATH,
 } from "../../../../config";
-import { sleep, SLEEP_TIME_MS } from "../../../../utils/helpers";
+import { getExchangeRateValueToSetForTesting, sleep, SLEEP_TIME_MS } from "../../../../utils/helpers";
 
 describe("Initialize parachain state", () => {
     let api: ApiPromise;
@@ -153,10 +153,9 @@ describe("Initialize parachain state", () => {
             // result will be medianized
             await initializeExchangeRate(exchangeRate, sudoInterBtcAPI.oracle);
         }
-        const exchangeRateValue = new Big("3855.23187");
-        await setCollateralExchangeRate(exchangeRateValue, Polkadot);
-        await setCollateralExchangeRate(exchangeRateValue, Kusama);
-        await setCollateralExchangeRate(exchangeRateValue, Kintsugi);
+        await setCollateralExchangeRate(getExchangeRateValueToSetForTesting(Polkadot), Polkadot);
+        await setCollateralExchangeRate(getExchangeRateValueToSetForTesting(Kusama), Kusama);
+        await setCollateralExchangeRate(getExchangeRateValueToSetForTesting(Kintsugi), Kintsugi);
     });
 
     it("should set BTC tx fees", async () => {

--- a/test/utils/helpers.ts
+++ b/test/utils/helpers.ts
@@ -2,6 +2,7 @@ import { Bitcoin, BitcoinUnit, Currency, ExchangeRate } from "@interlay/monetary
 import { ApiPromise, Keyring } from "@polkadot/api";
 import { KeyringPair } from "@polkadot/keyring/types";
 import { mnemonicGenerate } from "@polkadot/util-crypto";
+import Big from "big.js";
 import * as bitcoinjs from "bitcoinjs-lib";
 import { BitcoinCoreClient, InterBtcApi, CollateralCurrency, CollateralUnit, OracleAPI, VaultStatusExt } from "../../src";
 import { TransactionAPI } from "../../src/parachain/transaction";
@@ -142,3 +143,8 @@ export const vaultStatusToLabel = (status: VaultStatusExt): string => {
             return "Liquidated";
     }
 };
+
+// use the same exchange rate as the running oracles use 
+// to avoid flaky tests due to updated prices from the oracle client(s)
+// note: currently the same for all collateral currencies - might change in future
+export const getExchangeRateValueToSetForTesting = (collateralCurrency: CollateralCurrency): Big => new Big("230.0");

--- a/test/utils/helpers.ts
+++ b/test/utils/helpers.ts
@@ -1,11 +1,10 @@
-import { Bitcoin, BitcoinUnit, Currency, ExchangeRate } from "@interlay/monetary-js";
-import { ApiPromise, Keyring } from "@polkadot/api";
+import { Bitcoin, BitcoinUnit, Currency, ExchangeRate, UnitList } from "@interlay/monetary-js";
+import { Keyring } from "@polkadot/api";
 import { KeyringPair } from "@polkadot/keyring/types";
 import { mnemonicGenerate } from "@polkadot/util-crypto";
 import Big from "big.js";
 import * as bitcoinjs from "bitcoinjs-lib";
 import { BitcoinCoreClient, InterBtcApi, CollateralCurrency, CollateralUnit, OracleAPI, VaultStatusExt } from "../../src";
-import { TransactionAPI } from "../../src/parachain/transaction";
 import { SUDO_URI } from "../config";
 
 export const SLEEP_TIME_MS = 1000;
@@ -147,4 +146,4 @@ export const vaultStatusToLabel = (status: VaultStatusExt): string => {
 // use the same exchange rate as the running oracles use 
 // to avoid flaky tests due to updated prices from the oracle client(s)
 // note: currently the same for all collateral currencies - might change in future
-export const getExchangeRateValueToSetForTesting = (collateralCurrency: CollateralCurrency): Big => new Big("230.0");
+export const getExchangeRateValueToSetForTesting = <U extends UnitList>(collateralCurrency: Currency<U>): Big => new Big("230.0");


### PR DESCRIPTION
This fix is to have tests/setup code that modify the exchange rates to use the same values as the oracles do.

Previously, when an oracle would update the price to something other than it was before, it could change the result of getting the current exchange rate (depending on aggregate value) and certain validations, particularly on collaterization rates, would fail seemingly at random as expected values were not met by actual values returned.