### PR TITLE
fix: enable rpc decoration

### DIFF
--- a/src/factory.ts
+++ b/src/factory.ts
@@ -22,7 +22,9 @@ export function createProvider(endpoint: string, autoConnect?: number | false | 
 
 export function createSubstrateAPI(endpoint: string, autoConnect?: number | false | undefined): Promise<ApiPromise> {
     const provider = createProvider(endpoint, autoConnect);
-    return ApiPromise.create({ provider });
+    const types = getAPITypes();
+    const rpc = getRPCTypes();
+    return ApiPromise.create({ provider, types, rpc });
 }
 
 export async function createInterBtcApi(


### PR DESCRIPTION
Without this fix, scripts output `API/INIT: RPC methods not decorated`, and when trying to use rpcs the script crashes with `TypeError: Cannot read property '<function>' of undefined`.

With this fix, I can successfully call rpcs.

I don't know too much about this code base, so I don't know if adding the types and rpc definitions has any other effects besides the intended one of enabling rpcs.