### PR TITLE
fix: use ceil instead of round to calculate btc tx vsize

### DIFF
--- a/test/integration/parachain/staging/sequential/redeem.test.ts
+++ b/test/integration/parachain/staging/sequential/redeem.test.ts
@@ -136,7 +136,7 @@ describe("redeem", () => {
 
             const actualTxFeeSatoshi = new Big(btcTx.fee || 0);
             const actualTxVsize = calculateBtcTxVsize(btcTx);
-            if (actualTxVsize.eq(0)) {
+            if (actualTxVsize === 0) {
                 assert.fail(`Invalid actual tx vsize of 0, cannot calculate fee rate for redeem request id ${redeemRequest.id}`);
                 return;
             }

--- a/test/utils/helpers.ts
+++ b/test/utils/helpers.ts
@@ -158,7 +158,7 @@ export const getExchangeRateValueToSetForTesting = <U extends UnitList>(collater
  * @param transaction the transaction to calculate the vsize of
  * @returns the vsize of the transaction
  */
-export const calculateBtcTxVsize = (transaction: Transaction): Big => {
+export const calculateBtcTxVsize = (transaction: Transaction): number => {
     const txWeight = new Big(transaction.weight || 0);
-    return txWeight.div(4).round(0, RoundingMode.RoundUp);
+    return Math.ceil(txWeight.div(4).toNumber());
 };


### PR DESCRIPTION
BTC transaction vsize needs a `ceil`, not `round`.