### PR TITLE
test: add temporary debug print for btc tx in fee rate tests

### DIFF
--- a/test/integration/parachain/staging/sequential/redeem.test.ts
+++ b/test/integration/parachain/staging/sequential/redeem.test.ts
@@ -134,6 +134,10 @@ describe("redeem", () => {
             // get the actual values on the BTC transaction
             const btcTx = await interBtcAPI.electrsAPI.getTx(txId);
 
+            // TODO: remove at later stage. print debug info while we seem to have occasional failures
+            const btcTxDetails = JSON.stringify(btcTx, null, 2);
+            console.log(`BTC transaction details:\n ${btcTxDetails} `);
+
             const actualTxFeeSatoshi = new Big(btcTx.fee || 0);
             const actualTxVsize = calculateBtcTxVsize(btcTx);
             if (actualTxVsize.eq(0)) {

--- a/test/integration/parachain/staging/sequential/redeem.test.ts
+++ b/test/integration/parachain/staging/sequential/redeem.test.ts
@@ -135,8 +135,7 @@ describe("redeem", () => {
             const btcTx = await interBtcAPI.electrsAPI.getTx(txId);
 
             // TODO: remove at later stage. print debug info while we seem to have occasional failures
-            const btcTxDetails = JSON.stringify(btcTx, null, 2);
-            console.log(`BTC transaction details:\n ${btcTxDetails} `);
+            console.log(`BTC transaction details:\n ${JSON.stringify(btcTx)} `);
 
             const actualTxFeeSatoshi = new Big(btcTx.fee || 0);
             const actualTxVsize = calculateBtcTxVsize(btcTx);

--- a/test/integration/parachain/staging/sequential/redeem.test.ts
+++ b/test/integration/parachain/staging/sequential/redeem.test.ts
@@ -135,7 +135,7 @@ describe("redeem", () => {
             const btcTx = await interBtcAPI.electrsAPI.getTx(txId);
 
             // TODO: remove at later stage. print debug info while we seem to have occasional failures
-            console.log(`BTC transaction details:\n ${JSON.stringify(btcTx)} `);
+            console.log(`BTC transaction details:\n${JSON.stringify(btcTx)} `);
 
             const actualTxFeeSatoshi = new Big(btcTx.fee || 0);
             const actualTxVsize = calculateBtcTxVsize(btcTx);


### PR DESCRIPTION
While we have the odd failing test for fee rate comparisons (BTC tx fee rate vs expected oracle fee rate), add some debug prints for that specific test to better understand where the error might come from.