### PR TITLE
Fix burn exchange rate calculation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@interlay/interbtc-api",
-  "version": "1.13.1",
+  "version": "1.13.2",
   "description": "JavaScript library to interact with interBTC and kBTC",
   "main": "build/src/index.js",
   "typings": "build/src/index.d.ts",

--- a/src/parachain/redeem.ts
+++ b/src/parachain/redeem.ts
@@ -298,14 +298,16 @@ export class DefaultRedeemAPI implements RedeemAPI {
         const liquidationVault = await this.vaultsAPI.getLiquidationVault(
             collateralCurrency as unknown as CollateralCurrency
         );
-        const issuedAmount = liquidationVault.issuedTokens.add(liquidationVault.toBeIssuedTokens);
-        if (issuedAmount.isZero()) {
+        const burnableAmount = liquidationVault.issuedTokens
+            .add(liquidationVault.toBeIssuedTokens)
+            .sub(liquidationVault.toBeRedeemedTokens);
+        if (burnableAmount.isZero()) {
             return Promise.reject(new Error("There are no burnable tokens. The burn exchange rate is undefined"));
         }
         const collateralAmount = liquidationVault.collateral;
         const exchangeRate = collateralAmount
             .toBig(collateralAmount.currency.base)
-            .div(issuedAmount.toBig(Bitcoin.units.BTC));
+            .div(burnableAmount.toBig(Bitcoin.units.BTC));
         return new ExchangeRate<Bitcoin, BitcoinUnit, typeof collateralCurrency, typeof collateralCurrency.units>(
             Bitcoin,
             collateralCurrency,

--- a/test/unit/parachain/redeem.test.ts
+++ b/test/unit/parachain/redeem.test.ts
@@ -1,0 +1,68 @@
+import { expect } from "../../chai";
+import sinon from "sinon";
+import { DefaultRedeemAPI, DefaultVaultsAPI, newMonetaryAmount, VaultsAPI } from "../../../src";
+import { ExchangeRate, KBtc, Kintsugi } from "@interlay/monetary-js";
+
+describe("DefaultRedeemAPI", () => {
+    let redeemApi: DefaultRedeemAPI;
+
+    let stubbedVaultsApi: sinon.SinonStubbedInstance<DefaultVaultsAPI>;
+
+    beforeEach(() => {
+        // only mock/stub what we really need
+        // add more if/when needed
+        stubbedVaultsApi = sinon.createStubInstance(DefaultVaultsAPI);
+        redeemApi = new DefaultRedeemAPI(
+            null as any,
+            null as any,
+            null as any,
+            null as any,
+            stubbedVaultsApi as VaultsAPI,
+            null as any,
+            null as any
+        );
+    });
+
+    afterEach(() => {
+        sinon.restore();
+        sinon.reset();
+    });
+
+    describe("getBurnExchangeRate", () => {
+        afterEach(() => {
+            sinon.restore();
+            sinon.reset();
+        });
+
+        it("should reject if burnable amount is zero", async () => {
+            const zeroKbtcAmount = newMonetaryAmount(0, KBtc);
+            const mockVaultExt = {
+                toBeIssuedTokens: zeroKbtcAmount,
+                issuedTokens: zeroKbtcAmount,
+                toBeRedeemedTokens: zeroKbtcAmount,
+                collateral: newMonetaryAmount(10, Kintsugi),
+            };
+
+            // stub internal call to reutn our mocked vault
+            stubbedVaultsApi.getLiquidationVault.withArgs(sinon.match.any).resolves(mockVaultExt as any);
+
+            await expect(redeemApi.getBurnExchangeRate(Kintsugi)).to.be.rejectedWith("no burnable tokens");
+        });
+
+        it("should return an exchange rate", async () => {
+            const mockVaultExt = {
+                toBeIssuedTokens: newMonetaryAmount(1, KBtc),
+                issuedTokens: newMonetaryAmount(10, KBtc),
+                toBeRedeemedTokens: newMonetaryAmount(2, KBtc),
+                collateral: newMonetaryAmount(100, Kintsugi),
+            };
+
+            // stub internal call to reutn our mocked vault
+            stubbedVaultsApi.getLiquidationVault.withArgs(sinon.match.any).resolves(mockVaultExt as any);
+
+            const exchangeRate = await redeemApi.getBurnExchangeRate(Kintsugi);
+            expect(exchangeRate).to.be.an.instanceof(ExchangeRate);
+            expect(exchangeRate.rate.toNumber()).to.be.greaterThan(0);
+        });
+    });
+});

--- a/test/unit/parachain/redeem.test.ts
+++ b/test/unit/parachain/redeem.test.ts
@@ -2,6 +2,7 @@ import { expect } from "../../chai";
 import sinon from "sinon";
 import { DefaultRedeemAPI, DefaultVaultsAPI, newMonetaryAmount, VaultsAPI } from "../../../src";
 import { ExchangeRate, KBtc, Kintsugi } from "@interlay/monetary-js";
+import Big from "big.js";
 
 describe("DefaultRedeemAPI", () => {
     let redeemApi: DefaultRedeemAPI;
@@ -63,6 +64,33 @@ describe("DefaultRedeemAPI", () => {
             const exchangeRate = await redeemApi.getBurnExchangeRate(Kintsugi);
             expect(exchangeRate).to.be.an.instanceof(ExchangeRate);
             expect(exchangeRate.rate.toNumber()).to.be.greaterThan(0);
+        });
+
+        it("should return a specific exchange rate for given values", async () => {
+            // This test serves as canary / regression test when code gets refactored.
+            // Using specific values from when we found an issue with the calculation.
+            const mockVaultExt = {
+                toBeIssuedTokens: newMonetaryAmount(1000, KBtc),
+                issuedTokens: newMonetaryAmount(300000, KBtc),
+                toBeRedeemedTokens: newMonetaryAmount(200000, KBtc),
+                collateral: newMonetaryAmount(Big("39518270000"), Kintsugi),
+            };
+
+            // nmagic number of which rate to expect with collateral / (issued + toBeIssued - toBeRedeemed)
+            // (manually calculated)
+            const expectedExchangeRate = Big("391270");
+            // bring the numbers back down into a easier readable range of a JS number (expect 3.9127)
+            const testMultiplier = 0.00001;
+
+            // stub internal call to reutn our mocked vault
+            stubbedVaultsApi.getLiquidationVault.withArgs(sinon.match.any).resolves(mockVaultExt as any);
+
+            const exchangeRate = await redeemApi.getBurnExchangeRate(Kintsugi);
+            expect(exchangeRate).to.be.an.instanceof(ExchangeRate);
+            expect(exchangeRate.rate.mul(testMultiplier).toNumber()).to.be.closeTo(
+                expectedExchangeRate.mul(testMultiplier).toNumber(),
+                0.000001
+            );
         });
     });
 });


### PR DESCRIPTION
Fixed burn exchange rate from `x * collateral / (issued + toBeIssued)` to `x * collateral / (issued + toBeIssued - toBeRedeemed)`.

Added unit tests in addition to pre-existing integration tests, particularly for the rejection case.