### PR TITLE
Chore: Update monetary-js, and remove currency units

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   "dependencies": {
     "@interlay/esplora-btc-api": "0.4.0",
     "@interlay/interbtc-types": "1.7.0",
-    "@interlay/monetary-js": "0.6.0",
+    "@interlay/monetary-js": "0.7.0",
     "@polkadot/api": "8.8.2",
     "@types/big.js": "6.1.2",
     "big.js": "6.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@interlay/interbtc-api",
-  "version": "1.13.3",
+  "version": "1.14.0",
   "description": "JavaScript library to interact with interBTC and kBTC",
   "main": "build/src/index.js",
   "typings": "build/src/index.d.ts",

--- a/src/external/electrs.ts
+++ b/src/external/electrs.ts
@@ -13,7 +13,8 @@ import { AxiosResponse } from "axios";
 import * as bitcoinjs from "bitcoinjs-lib";
 import { TypeRegistry } from "@polkadot/types";
 import { Bytes } from "@polkadot/types";
-import { BitcoinAmount } from "@interlay/monetary-js";
+import { Bitcoin, BitcoinAmount } from "@interlay/monetary-js";
+import { atomicToBaseAmount } from "../utils";
 
 export const MAINNET_ESPLORA_BASE_PATH = "https://btc-mainnet.interlay.io";
 export const TESTNET_ESPLORA_BASE_PATH = "https://btc-testnet.interlay.io";
@@ -262,7 +263,8 @@ export class DefaultElectrsAPI implements ElectrsAPI {
             if (txo.value === undefined) {
                 return false;
             } else {
-                const utxoValue = BitcoinAmount.from.Satoshi(txo.value);
+                const atomicValue = atomicToBaseAmount(txo.value, Bitcoin);
+                const utxoValue = new BitcoinAmount(atomicValue);
                 return utxoValue.gte(amount);
             }
         }

--- a/src/interbtc-api.ts
+++ b/src/interbtc-api.ts
@@ -2,7 +2,6 @@ import { ApiPromise } from "@polkadot/api";
 import { AddressOrPair } from "@polkadot/api/submittable/types";
 import { Signer } from "@polkadot/api/types";
 import { KeyringPair } from "@polkadot/keyring/types";
-import { BitcoinUnit, Currency } from "@interlay/monetary-js";
 
 import { ElectrsAPI, DefaultElectrsAPI } from "./external/electrs";
 import { DefaultNominationAPI, NominationAPI } from "./parachain/nomination";
@@ -21,7 +20,7 @@ import { Network, networks } from "bitcoinjs-lib";
 import { BitcoinNetwork } from "./types/bitcoinTypes";
 import { DefaultRewardsAPI, RewardsAPI } from "./parachain/rewards";
 import { DefaultTransactionAPI, TransactionAPI } from "./parachain/transaction";
-import { currencyIdToMonetaryCurrency, GovernanceCurrency, GovernanceUnit, WrappedCurrency } from "./types";
+import { currencyIdToMonetaryCurrency, GovernanceCurrency, WrappedCurrency } from "./types";
 import { DefaultEscrowAPI, EscrowAPI } from ".";
 import { AssetRegistryAPI, DefaultAssetRegistryAPI } from "./parachain/asset-registry";
 
@@ -59,8 +58,8 @@ export interface InterBtcApi {
     setAccount(account: AddressOrPair, signer?: Signer): void;
     removeAccount(): void;
     readonly account: AddressOrPair | undefined;
-    getGovernanceCurrency(): Currency<GovernanceUnit>;
-    getWrappedCurrency(): Currency<BitcoinUnit>;
+    getGovernanceCurrency(): GovernanceCurrency;
+    getWrappedCurrency(): WrappedCurrency;
 }
 
 /**
@@ -177,12 +176,12 @@ export class DefaultInterBtcApi implements InterBtcApi {
         return this.transactionAPI.getAccount();
     }
 
-    public getGovernanceCurrency(): Currency<GovernanceUnit> {
+    public getGovernanceCurrency(): GovernanceCurrency {
         const currencyId = this.api.consts.escrowRewards.getNativeCurrencyId;
         return currencyIdToMonetaryCurrency(currencyId);
     }
 
-    public getWrappedCurrency(): Currency<BitcoinUnit> {
+    public getWrappedCurrency(): WrappedCurrency {
         const currencyId = this.api.consts.escrowRewards.getWrappedCurrencyId;
         return currencyIdToMonetaryCurrency(currencyId);
     }

--- a/src/parachain/nomination.ts
+++ b/src/parachain/nomination.ts
@@ -17,11 +17,9 @@ import { TransactionAPI } from "./transaction";
 import {
     CollateralCurrency,
     CollateralIdLiteral,
-    CollateralUnit,
     CurrencyIdLiteral,
     currencyIdToLiteral,
     currencyIdToMonetaryCurrency,
-    CurrencyUnit,
     NominationStatus,
     tickerToCurrencyIdLiteral,
     WrappedCurrency,
@@ -34,16 +32,16 @@ export enum NominationAmountType {
     Raw = "raw",
     Parsed = "parsed",
 }
-export type NominationData<U extends CurrencyUnit> = {
+export type NominationData = {
     nonce: number;
     vaultId: InterbtcPrimitivesVaultId;
     nominatorId: AccountId;
-    amount: MonetaryAmount<Currency<U>, U>;
+    amount: MonetaryAmount<Currency>;
 };
 
-export type RawNomination = NominationData<CollateralUnit> & { type: NominationAmountType.Raw };
-export type Nomination = NominationData<CollateralUnit> & { type: NominationAmountType.Parsed };
-export type NominationReward = NominationData<CurrencyUnit>;
+export type RawNomination = NominationData & { type: NominationAmountType.Raw };
+export type Nomination = NominationData & { type: NominationAmountType.Parsed };
+export type NominationReward = NominationData;
 
 /**
  * @category BTC Bridge
@@ -53,18 +51,12 @@ export interface NominationAPI {
      * @param vaultAccountId Vault to nominate collateral to
      * @param amount Amount to deposit, as a `Monetary.js` object
      */
-    depositCollateral<C extends CollateralUnit>(
-        vaultAccountId: AccountId,
-        amount: MonetaryAmount<Currency<C>, C>
-    ): Promise<void>;
+    depositCollateral(vaultAccountId: AccountId, amount: MonetaryAmount<CollateralCurrency>): Promise<void>;
     /**
      * @param vaultAccountId Vault that collateral was nominated to
      * @param amount Amount to withdraw, as a `Monetary.js` object
      */
-    withdrawCollateral<C extends CollateralUnit>(
-        vaultAccountId: AccountId,
-        amount: MonetaryAmount<Currency<C>, C>
-    ): Promise<void>;
+    withdrawCollateral(vaultAccountId: AccountId, amount: MonetaryAmount<CollateralCurrency>): Promise<void>;
     /**
      * @param collateralCurrency Currency to accept as nomination
      * @remarks Function callable by vaults to opt in to the nomination feature
@@ -123,7 +115,7 @@ export interface NominationAPI {
         vaultAccountId?: AccountId,
         collateralCurrency?: CollateralCurrency,
         nominatorId?: AccountId
-    ): Promise<MonetaryAmount<Currency<CollateralUnit>, CollateralUnit>>;
+    ): Promise<MonetaryAmount<CollateralCurrency>>;
     /**
      *
      * @param nominatorId Id of user who nominated to one or more vaults
@@ -142,7 +134,7 @@ export interface NominationAPI {
         collateralCurrencyId: CollateralIdLiteral,
         rewardCurrencyId: CurrencyIdLiteral,
         nominatorId: AccountId
-    ): Promise<MonetaryAmount<Currency<CurrencyUnit>, CurrencyUnit>>;
+    ): Promise<MonetaryAmount<CollateralCurrency>>;
     /**
      * @returns A map (vaultId => nonce), representing the nonces for each reward pool with the given currency
      */
@@ -158,10 +150,7 @@ export class DefaultNominationAPI implements NominationAPI {
         private transactionAPI: TransactionAPI
     ) {}
 
-    async depositCollateral<C extends CollateralUnit>(
-        vaultAccountId: AccountId,
-        amount: MonetaryAmount<Currency<C>, C>
-    ): Promise<void> {
+    async depositCollateral(vaultAccountId: AccountId, amount: MonetaryAmount<CollateralCurrency>): Promise<void> {
         const vaultId = newVaultId(
             this.api,
             vaultAccountId.toString(),
@@ -173,18 +162,13 @@ export class DefaultNominationAPI implements NominationAPI {
         await this.transactionAPI.sendLogged(tx, this.api.events.nomination.DepositCollateral, true);
     }
 
-    async withdrawCollateral<C extends CollateralUnit>(
+    async withdrawCollateral(
         vaultAccountId: AccountId,
-        amount: MonetaryAmount<Currency<C>, C>,
+        amount: MonetaryAmount<CollateralCurrency>,
         nonce?: number
     ): Promise<void> {
         const currencyIdLiteral = tickerToCurrencyIdLiteral(amount.currency.ticker) as CollateralIdLiteral;
-        const vaultId = newVaultId(
-            this.api,
-            vaultAccountId.toString(),
-            amount.currency as unknown as CollateralCurrency,
-            this.wrappedCurrency
-        );
+        const vaultId = newVaultId(this.api, vaultAccountId.toString(), amount.currency, this.wrappedCurrency);
         const definedNonce = nonce
             ? nonce
             : await this.rewardsAPI.getStakingPoolNonce(currencyIdLiteral, vaultAccountId);
@@ -238,15 +222,13 @@ export class DefaultNominationAPI implements NominationAPI {
                 const nonce = storageKeyToNthInner(v[0], 0) as Index;
                 const [vaultId, nominatorId] = storageKeyToNthInner(v[0], 1) as [InterbtcPrimitivesVaultId, AccountId];
                 const nomination = decodeFixedPointType(v[1] as UnsignedFixedPoint);
-                const collateralCurrency = currencyIdToMonetaryCurrency(
-                    vaultId.currencies.collateral
-                ) as Currency<CurrencyUnit>;
+                const collateralCurrency = currencyIdToMonetaryCurrency(vaultId.currencies.collateral);
                 const monetaryNomination = newMonetaryAmount(nomination, collateralCurrency, true);
                 return {
                     nonce: nonce.toNumber(),
                     vaultId,
                     nominatorId,
-                    amount: monetaryNomination as MonetaryAmount<Currency<CollateralUnit>, CollateralUnit>,
+                    amount: monetaryNomination,
                     type: NominationAmountType.Raw,
                 };
             })
@@ -291,7 +273,7 @@ export class DefaultNominationAPI implements NominationAPI {
         collateralCurrencyId: CollateralIdLiteral,
         rewardCurrencyId: CurrencyIdLiteral,
         nominatorId: AccountId
-    ): Promise<MonetaryAmount<Currency<CurrencyUnit>, CurrencyUnit>> {
+    ): Promise<MonetaryAmount<Currency>> {
         return await this.vaultsAPI.computeReward(vaultId, nominatorId, collateralCurrencyId, rewardCurrencyId);
     }
 
@@ -353,7 +335,7 @@ export class DefaultNominationAPI implements NominationAPI {
         vaultId?: AccountId,
         collateralCurrency?: CollateralCurrency,
         nominatorId?: AccountId
-    ): Promise<MonetaryAmount<Currency<CollateralUnit>, CollateralUnit>> {
+    ): Promise<MonetaryAmount<CollateralCurrency>> {
         const collateralCurrencyId = collateralCurrency
             ? tickerToCurrencyIdLiteral(collateralCurrency.ticker)
             : undefined;
@@ -362,7 +344,7 @@ export class DefaultNominationAPI implements NominationAPI {
             // Cannot return `zero` because the type of nominated collateral is unknown
             return Promise.reject("No nomination available");
         }
-        const zero = newMonetaryAmount<CollateralUnit>(0, collateralCurrency as Currency<CollateralUnit>);
+        const zero = newMonetaryAmount(0, collateralCurrency as Currency);
         return filteredNominations
             .filter((nomination) => {
                 const wrappedVaultCurrency = currencyIdToMonetaryCurrency(nomination.vaultId.currencies.wrapped);

--- a/src/parachain/nomination.ts
+++ b/src/parachain/nomination.ts
@@ -157,7 +157,7 @@ export class DefaultNominationAPI implements NominationAPI {
             amount.currency as unknown as CollateralCurrency,
             this.wrappedCurrency
         );
-        const amountAsPlanck = this.api.createType("Balance", amount.toString());
+        const amountAsPlanck = this.api.createType("Balance", amount.toString(true));
         const tx = this.api.tx.nomination.depositCollateral(vaultId, amountAsPlanck);
         await this.transactionAPI.sendLogged(tx, this.api.events.nomination.DepositCollateral, true);
     }
@@ -172,7 +172,7 @@ export class DefaultNominationAPI implements NominationAPI {
         const definedNonce = nonce
             ? nonce
             : await this.rewardsAPI.getStakingPoolNonce(currencyIdLiteral, vaultAccountId);
-        const amountAsPlanck = this.api.createType("Balance", amount.toString());
+        const amountAsPlanck = this.api.createType("Balance", amount.toString(true));
         const parsedNonce = this.api.createType("Index", definedNonce);
         const tx = this.api.tx.nomination.withdrawCollateral(vaultId, amountAsPlanck, parsedNonce);
         await this.transactionAPI.sendLogged(tx, this.api.events.nomination.WithdrawCollateral, true);

--- a/src/parachain/replace.ts
+++ b/src/parachain/replace.ts
@@ -2,7 +2,7 @@ import { ApiPromise } from "@polkadot/api";
 import { H256, AccountId } from "@polkadot/types/interfaces";
 import { BlockNumber } from "@polkadot/types/interfaces/runtime";
 import { Network } from "bitcoinjs-lib";
-import { BitcoinUnit, Currency, MonetaryAmount } from "@interlay/monetary-js";
+import { MonetaryAmount } from "@interlay/monetary-js";
 import { isKeyringPair } from "@polkadot/api/util";
 import { InterbtcPrimitivesReplaceReplaceRequest, BitcoinAddress } from "@polkadot/types/lookup";
 
@@ -18,7 +18,7 @@ import {
 import { FeeAPI } from "./fee";
 import { TransactionAPI } from "./transaction";
 import { ElectrsAPI } from "../external";
-import { CollateralCurrency, CollateralUnit, ReplaceRequestExt, WrappedCurrency } from "../types";
+import { CollateralCurrency, ReplaceRequestExt, WrappedCurrency } from "../types";
 import { VaultsAPI } from "../parachain";
 
 /**
@@ -29,7 +29,7 @@ export interface ReplaceAPI {
      * @returns The minimum amount of btc that is accepted for replace requests; any lower values would
      * risk the bitcoin client to reject the payment
      */
-    getDustValue(): Promise<MonetaryAmount<WrappedCurrency, BitcoinUnit>>;
+    getDustValue(): Promise<MonetaryAmount<WrappedCurrency>>;
     /**
      * @returns The time difference in number of blocks between when a replace request is created
      * and required completion time by a vault. The replace period has an upper limit
@@ -53,20 +53,14 @@ export interface ReplaceAPI {
      * @param amount Amount issued, denoted in Bitcoin, to have replaced by another vault
      * @param collateralCurrency Collateral currency to have replaced
      */
-    request(
-        amount: MonetaryAmount<WrappedCurrency, BitcoinUnit>,
-        collateralCurrency: CollateralCurrency
-    ): Promise<void>;
+    request(amount: MonetaryAmount<WrappedCurrency>, collateralCurrency: CollateralCurrency): Promise<void>;
     /**
      * Wihdraw a replace request
      * @param amount The amount of wrapped tokens to withdraw from the amount
      * requested to have replaced.
      * @param collateralCurrency Collateral currency of the request
      */
-    withdraw(
-        amount: MonetaryAmount<WrappedCurrency, BitcoinUnit>,
-        collateralCurrency: CollateralCurrency
-    ): Promise<void>;
+    withdraw(amount: MonetaryAmount<WrappedCurrency>, collateralCurrency: CollateralCurrency): Promise<void>;
     /**
      * Accept a replace request
      * @param oldVault ID of the old vault that to be (possibly partially) replaced
@@ -76,8 +70,8 @@ export interface ReplaceAPI {
      */
     accept(
         oldVault: AccountId,
-        amount: MonetaryAmount<WrappedCurrency, BitcoinUnit>,
-        collateral: MonetaryAmount<Currency<CollateralUnit>, CollateralUnit>,
+        amount: MonetaryAmount<WrappedCurrency>,
+        collateral: MonetaryAmount<CollateralCurrency>,
         btcAddress: string
     ): Promise<void>;
     /**
@@ -109,11 +103,8 @@ export class DefaultReplaceAPI implements ReplaceAPI {
         private transactionAPI: TransactionAPI
     ) {}
 
-    async request(
-        amount: MonetaryAmount<WrappedCurrency, BitcoinUnit>,
-        collateralCurrency: CollateralCurrency
-    ): Promise<void> {
-        const amountAtomicUnit = this.api.createType("Balance", amount.str.Satoshi());
+    async request(amount: MonetaryAmount<WrappedCurrency>, collateralCurrency: CollateralCurrency): Promise<void> {
+        const amountAtomicUnit = this.api.createType("Balance", amount.toString(true));
         // Assumes the calling account is the `vaultId`
         const vaultAccount = this.transactionAPI.getAccount();
         if (vaultAccount === undefined) {
@@ -125,11 +116,8 @@ export class DefaultReplaceAPI implements ReplaceAPI {
         await this.transactionAPI.sendLogged(requestTx, this.api.events.replace.RequestReplace);
     }
 
-    async withdraw(
-        amount: MonetaryAmount<WrappedCurrency, BitcoinUnit>,
-        collateralCurrency: CollateralCurrency
-    ): Promise<void> {
-        const amountAtomicUnit = this.api.createType("Balance", amount.str.Satoshi());
+    async withdraw(amount: MonetaryAmount<WrappedCurrency>, collateralCurrency: CollateralCurrency): Promise<void> {
+        const amountAtomicUnit = this.api.createType("Balance", amount.toString(true));
         const vaultCurrencyPair = newVaultCurrencyPair(this.api, collateralCurrency, this.wrappedCurrency);
         const requestTx = this.api.tx.replace.withdrawReplace(vaultCurrencyPair, amountAtomicUnit);
         await this.transactionAPI.sendLogged(requestTx, this.api.events.replace.WithdrawReplace, true);
@@ -137,13 +125,13 @@ export class DefaultReplaceAPI implements ReplaceAPI {
 
     async accept(
         oldVault: AccountId,
-        amount: MonetaryAmount<WrappedCurrency, BitcoinUnit>,
-        collateral: MonetaryAmount<Currency<CollateralUnit>, CollateralUnit>,
+        amount: MonetaryAmount<WrappedCurrency>,
+        collateral: MonetaryAmount<CollateralCurrency>,
         btcAddress: string
     ): Promise<void> {
         const parsedBtcAddress = this.api.createType<BitcoinAddress>("BitcoinAddress", btcAddress);
-        const amountAtomicUnit = this.api.createType("Balance", amount.str.Satoshi());
-        const collateralAtomicUnit = this.api.createType("Balance", collateral.toString(collateral.currency.rawBase));
+        const amountAtomicUnit = this.api.createType("Balance", amount.toString(true));
+        const collateralAtomicUnit = this.api.createType("Balance", collateral.toString(true));
         const vaultCurrencyPair = newVaultCurrencyPair(
             this.api,
             collateral.currency as CollateralCurrency,
@@ -170,7 +158,7 @@ export class DefaultReplaceAPI implements ReplaceAPI {
         await this.transactionAPI.sendLogged(tx, this.api.events.replace.ExecuteReplace, true);
     }
 
-    async getDustValue(): Promise<MonetaryAmount<WrappedCurrency, BitcoinUnit>> {
+    async getDustValue(): Promise<MonetaryAmount<WrappedCurrency>> {
         const dustSatoshi = await this.api.query.replace.replaceBtcDustValue();
         return newMonetaryAmount(dustSatoshi.toString(), this.wrappedCurrency);
     }

--- a/src/parachain/tokens.ts
+++ b/src/parachain/tokens.ts
@@ -97,7 +97,7 @@ export class DefaultTokensAPI implements TokensAPI {
     }
 
     async transfer(destination: string, amount: MonetaryAmount<Currency>): Promise<void> {
-        const amountAtomicUnit = this.api.createType("Balance", amount.toString());
+        const amountAtomicUnit = this.api.createType("Balance", amount.toString(true));
         const currencyIdLiteral = tickerToCurrencyIdLiteral(amount.currency.ticker);
         const transferTransaction = this.api.tx.tokens.transfer(
             destination,

--- a/src/parachain/vaults.ts
+++ b/src/parachain/vaults.ts
@@ -347,7 +347,7 @@ export class DefaultVaultsAPI implements VaultsAPI {
     }
 
     async register(amount: MonetaryAmount<CollateralCurrency>, publicKey: string): Promise<void> {
-        const amountAtomicUnit = this.api.createType("Balance", amount.toString());
+        const amountAtomicUnit = this.api.createType("Balance", amount.toString(true));
         const currencyPair = newVaultCurrencyPair(
             this.api,
             tickerToMonetaryCurrency(this.api, amount.currency.ticker) as CollateralCurrency,
@@ -368,7 +368,7 @@ export class DefaultVaultsAPI implements VaultsAPI {
     }
 
     async withdrawCollateral(amount: MonetaryAmount<CollateralCurrency>): Promise<void> {
-        const amountAtomicUnit = this.api.createType("Balance", amount.toString());
+        const amountAtomicUnit = this.api.createType("Balance", amount.toString(true));
         const currencyPair = newVaultCurrencyPair(
             this.api,
             tickerToMonetaryCurrency(this.api, amount.currency.ticker) as CollateralCurrency,
@@ -379,7 +379,7 @@ export class DefaultVaultsAPI implements VaultsAPI {
     }
 
     async depositCollateral(amount: MonetaryAmount<CollateralCurrency>): Promise<void> {
-        const amountAsPlanck = this.api.createType("Balance", amount.toString());
+        const amountAsPlanck = this.api.createType("Balance", amount.toString(true));
         const currencyPair = newVaultCurrencyPair(
             this.api,
             tickerToMonetaryCurrency(this.api, amount.currency.ticker) as CollateralCurrency,
@@ -921,7 +921,7 @@ export class DefaultVaultsAPI implements VaultsAPI {
 
     private wrapCurrency(amount: MonetaryAmount<CollateralCurrency>): BalanceWrapper {
         return this.api.createType("BalanceWrapper", {
-            amount: this.api.createType("u128", amount.toString()),
+            amount: this.api.createType("u128", amount.toString(true)),
             currencyId: newCurrencyId(this.api, tickerToCurrencyIdLiteral(amount.currency.ticker)),
         });
     }

--- a/src/parachain/vaults.ts
+++ b/src/parachain/vaults.ts
@@ -2,7 +2,7 @@ import { ApiPromise } from "@polkadot/api";
 import { AccountId, BlockNumber, BlockHash } from "@polkadot/types/interfaces";
 import Big from "big.js";
 import { Network } from "bitcoinjs-lib";
-import { MonetaryAmount, Currency, BitcoinUnit } from "@interlay/monetary-js";
+import { MonetaryAmount, Currency } from "@interlay/monetary-js";
 import { Option } from "@polkadot/types";
 import {
     VaultRegistryVaultStatus,
@@ -28,7 +28,6 @@ import { FeeAPI } from "./fee";
 import { TransactionAPI } from "./transaction";
 import { ElectrsAPI } from "../external";
 import {
-    CollateralUnit,
     tickerToCurrencyIdLiteral,
     VaultExt,
     SystemVaultExt,
@@ -42,8 +41,6 @@ import {
     currencyIdToLiteral,
     tickerToMonetaryCurrency,
     currencyIdLiteralToMonetaryCurrency,
-    GovernanceUnit,
-    CurrencyUnit,
     GovernanceIdLiteral,
     GovernanceCurrency,
 } from "../types";
@@ -58,7 +55,7 @@ export interface VaultsAPI {
     /**
      * @returns An array containing the vaults with non-zero backing collateral
      */
-    list(atBlock?: BlockHash): Promise<VaultExt<BitcoinUnit>[]>;
+    list(atBlock?: BlockHash): Promise<VaultExt[]>;
     /**
      * Get a vault by account ID and collateral currency.
      * Does not reject if the vault does not exist, but returns null instead.
@@ -66,17 +63,14 @@ export interface VaultsAPI {
      * @param collateralCurrencyIdLiteral Collateral used by vault
      * @returns A vault object, or null if no vault with the given ID and currency pair exists
      */
-    getOrNull(
-        vaultAccountId: AccountId,
-        collateralCurrencyIdLiteral: CurrencyIdLiteral
-    ): Promise<VaultExt<BitcoinUnit> | null>;
+    getOrNull(vaultAccountId: AccountId, collateralCurrencyIdLiteral: CurrencyIdLiteral): Promise<VaultExt | null>;
     /**
      * Get a vault by account ID and collateral currency. Rejects if no vault exists.
      * @param vaultAccountId The ID of the vault to fetch
      * @param collateralCurrencyIdLiteral Collateral used by vault
      * @returns A vault object, rejects if no vault with the given ID and currency pair exists
      */
-    get(vaultAccountId: AccountId, collateralCurrencyIdLiteral: CurrencyIdLiteral): Promise<VaultExt<BitcoinUnit>>;
+    get(vaultAccountId: AccountId, collateralCurrencyIdLiteral: CurrencyIdLiteral): Promise<VaultExt>;
     /**
      * Get the collateralization of a single vault measured by dividing the value of issued (wrapped) tokens
      * by the value of total locked collateral.
@@ -91,10 +85,10 @@ export interface VaultsAPI {
      * should only include the issued tokens, leaving out unsettled ("to-be-issued") tokens
      * @returns the vault collateralization
      */
-    getVaultCollateralization<C extends CollateralUnit>(
+    getVaultCollateralization(
         vaultAccountId: AccountId,
         collateralCurrencyIdLiteral: CollateralIdLiteral,
-        newCollateral?: MonetaryAmount<Currency<C>, C>,
+        newCollateral?: MonetaryAmount<CollateralCurrency>,
         onlyIssued?: boolean
     ): Promise<Big | undefined>;
     // /**
@@ -114,10 +108,10 @@ export interface VaultsAPI {
      * @returns The required collateral the vault needs to deposit to stay
      * above the threshold limit
      */
-    getRequiredCollateralForVault<C extends CollateralUnit>(
+    getRequiredCollateralForVault(
         vaultAccountId: AccountId,
-        collateralCurrency: Currency<C>
-    ): Promise<MonetaryAmount<Currency<C>, C>>;
+        collateralCurrency: CollateralCurrency
+    ): Promise<MonetaryAmount<CollateralCurrency>>;
     /**
      * Get the minimum secured collateral amount required to activate a vault
      * @param collateralCurrency The currency specification, a `Monetary.js` object
@@ -132,50 +126,44 @@ export interface VaultsAPI {
     getIssuedAmount(
         vaultAccountId: AccountId,
         collateralCurrency: CurrencyIdLiteral
-    ): Promise<MonetaryAmount<WrappedCurrency, BitcoinUnit>>;
+    ): Promise<MonetaryAmount<WrappedCurrency>>;
     /**
      * @returns The total amount of wrapped tokens issued by the vaults
      */
-    getTotalIssuedAmount(): Promise<MonetaryAmount<WrappedCurrency, BitcoinUnit>>;
+    getTotalIssuedAmount(): Promise<MonetaryAmount<WrappedCurrency>>;
     /**
      * @returns The total amount of wrapped tokens that can be issued, considering the collateral
      * locked by the vaults
      */
-    getTotalIssuableAmount(): Promise<MonetaryAmount<WrappedCurrency, BitcoinUnit>>;
+    getTotalIssuableAmount(): Promise<MonetaryAmount<WrappedCurrency>>;
     /**
      * @param collateral Amount of collateral to calculate issuable capacity for
      * @returns Issuable amount by the vault, given the collateral amount
      */
-    calculateCapacity<C extends CollateralUnit>(
-        collateral: MonetaryAmount<Currency<C>, C>
-    ): Promise<MonetaryAmount<Currency<BitcoinUnit>, BitcoinUnit>>;
+    calculateCapacity(collateral: MonetaryAmount<CollateralCurrency>): Promise<MonetaryAmount<WrappedCurrency>>;
     /**
      * @param amount Wrapped tokens amount to issue
      * @returns A vault that has sufficient collateral to issue the given amount
      */
-    selectRandomVaultIssue(amount: MonetaryAmount<WrappedCurrency, BitcoinUnit>): Promise<InterbtcPrimitivesVaultId>;
+    selectRandomVaultIssue(amount: MonetaryAmount<WrappedCurrency>): Promise<InterbtcPrimitivesVaultId>;
     /**
      * @param amount Wrapped tokens amount to redeem
      * @returns A vault that has issued sufficient wrapped tokens to redeem the given amount
      */
-    selectRandomVaultRedeem(amount: MonetaryAmount<WrappedCurrency, BitcoinUnit>): Promise<InterbtcPrimitivesVaultId>;
+    selectRandomVaultRedeem(amount: MonetaryAmount<WrappedCurrency>): Promise<InterbtcPrimitivesVaultId>;
     /**
      * @returns Vaults below the premium redeem threshold, sorted in descending order of their redeemable tokens
      */
-    getPremiumRedeemVaults(): Promise<Map<InterbtcPrimitivesVaultId, MonetaryAmount<WrappedCurrency, BitcoinUnit>>>;
+    getPremiumRedeemVaults(): Promise<Map<InterbtcPrimitivesVaultId, MonetaryAmount<WrappedCurrency>>>;
     /**
      * @returns Vaults with issuable tokens, not sorted in any particular order.
      * @remarks The result is not sorted as an attempt to randomize the assignment of requests to vaults.
      */
-    getVaultsWithIssuableTokens(): Promise<
-        Map<InterbtcPrimitivesVaultId, MonetaryAmount<WrappedCurrency, BitcoinUnit>>
-    >;
+    getVaultsWithIssuableTokens(): Promise<Map<InterbtcPrimitivesVaultId, MonetaryAmount<WrappedCurrency>>>;
     /**
      * @returns Vaults with redeemable tokens, sorted in descending order.
      */
-    getVaultsWithRedeemableTokens(): Promise<
-        Map<InterbtcPrimitivesVaultId, MonetaryAmount<WrappedCurrency, BitcoinUnit>>
-    >;
+    getVaultsWithRedeemableTokens(): Promise<Map<InterbtcPrimitivesVaultId, MonetaryAmount<WrappedCurrency>>>;
     /**
      * @param vaultId The vault ID
      * @param btcTxId ID of the Bitcoin transaction to check
@@ -237,16 +225,16 @@ export interface VaultsAPI {
     /**
      * @param amount The amount of collateral to withdraw
      */
-    withdrawCollateral<C extends CollateralUnit>(amount: MonetaryAmount<Currency<C>, C>): Promise<void>;
+    withdrawCollateral(amount: MonetaryAmount<CollateralCurrency>): Promise<void>;
     /**
      * @param amount The amount of extra collateral to lock
      */
-    depositCollateral<C extends CollateralUnit>(amount: MonetaryAmount<Currency<C>, C>): Promise<void>;
+    depositCollateral(amount: MonetaryAmount<CollateralCurrency>): Promise<void>;
     /**
      * @param collateralCurrency
      * @returns A vault object representing the liquidation vault
      */
-    getLiquidationVault(collateralCurrency: CollateralCurrency): Promise<SystemVaultExt<BitcoinUnit>>;
+    getLiquidationVault(collateralCurrency: CollateralCurrency): Promise<SystemVaultExt>;
     /**
      * @param vaultAccountId The vault account ID
      * @param collateralCurrency The currency specification, a `Monetary.js` object
@@ -255,7 +243,7 @@ export interface VaultsAPI {
     getCollateral(
         vaultId: AccountId,
         collateralCurrencyIdLiteral: CurrencyIdLiteral
-    ): Promise<MonetaryAmount<Currency<CollateralUnit>, CollateralUnit>>;
+    ): Promise<MonetaryAmount<CollateralCurrency>>;
     /**
      * @param collateralCurrency The collateral currency specification, a `Monetary.js` object
      * @returns The maximum collateral a vault can accept as nomination, as a ratio of its own collateral
@@ -269,7 +257,7 @@ export interface VaultsAPI {
     getStakingCapacity(
         vaultAccountId: AccountId,
         collateralCurrency: CurrencyIdLiteral
-    ): Promise<MonetaryAmount<Currency<CollateralUnit>, CollateralUnit>>;
+    ): Promise<MonetaryAmount<CollateralCurrency>>;
     /**
      * @param vaultId Vault ID object
      * @param nonce Nonce of the staking pool
@@ -278,7 +266,7 @@ export interface VaultsAPI {
     computeBackingCollateral(
         vaultId: InterbtcPrimitivesVaultId,
         nonce?: number
-    ): Promise<MonetaryAmount<Currency<CollateralUnit>, CollateralUnit>>;
+    ): Promise<MonetaryAmount<CollateralCurrency>>;
     /**
      * A relayer may report Vault misbehavior by providing a fraud proof
      * (malicious Bitcoin transaction and transaction inclusion proof).
@@ -308,7 +296,7 @@ export interface VaultsAPI {
         collateralCurrencyId: CollateralIdLiteral,
         rewardCurrencyIdLiteral: CurrencyIdLiteral,
         nonce?: number
-    ): Promise<MonetaryAmount<Currency<CurrencyUnit>, CurrencyUnit>>;
+    ): Promise<MonetaryAmount<Currency>>;
     /**
      * @param vaultAccountId The vault ID whose reward pool to check
      * @param vaultCollateralIdLiteral Collateral used by the vault
@@ -319,7 +307,7 @@ export interface VaultsAPI {
         vaultAccountId: AccountId,
         vaultCollateralIdLiteral: CollateralIdLiteral,
         rewardCurrencyIdLiteral: WrappedIdLiteral
-    ): Promise<MonetaryAmount<Currency<BitcoinUnit>, BitcoinUnit>>;
+    ): Promise<MonetaryAmount<WrappedCurrency>>;
     /**
      * @param vaultAccountId The vault ID whose reward pool to check
      * @param vaultCollateralIdLiteral Collateral used by the vault
@@ -330,7 +318,7 @@ export interface VaultsAPI {
         vaultAccountId: AccountId,
         vaultCollateralIdLiteral: CollateralIdLiteral,
         governanceCurrencyIdLiteral: GovernanceIdLiteral
-    ): Promise<MonetaryAmount<Currency<GovernanceUnit>, GovernanceUnit>>;
+    ): Promise<MonetaryAmount<GovernanceCurrency>>;
     /**
      * Enables or disables issue requests for given vault
      * @param vaultId The vault ID whose issuing will be toggled
@@ -358,7 +346,7 @@ export class DefaultVaultsAPI implements VaultsAPI {
         return this.wrappedCurrency;
     }
 
-    async register<C extends CollateralUnit>(amount: MonetaryAmount<Currency<C>, C>, publicKey: string): Promise<void> {
+    async register(amount: MonetaryAmount<CollateralCurrency>, publicKey: string): Promise<void> {
         const amountAtomicUnit = this.api.createType("Balance", amount.toString());
         const currencyPair = newVaultCurrencyPair(
             this.api,
@@ -379,7 +367,7 @@ export class DefaultVaultsAPI implements VaultsAPI {
         ]);
     }
 
-    async withdrawCollateral<C extends CollateralUnit>(amount: MonetaryAmount<Currency<C>, C>): Promise<void> {
+    async withdrawCollateral(amount: MonetaryAmount<CollateralCurrency>): Promise<void> {
         const amountAtomicUnit = this.api.createType("Balance", amount.toString());
         const currencyPair = newVaultCurrencyPair(
             this.api,
@@ -390,7 +378,7 @@ export class DefaultVaultsAPI implements VaultsAPI {
         await this.transactionAPI.sendLogged(tx, this.api.events.vaultRegistry.WithdrawCollateral, true);
     }
 
-    async depositCollateral<C extends CollateralUnit>(amount: MonetaryAmount<Currency<C>, C>): Promise<void> {
+    async depositCollateral(amount: MonetaryAmount<CollateralCurrency>): Promise<void> {
         const amountAsPlanck = this.api.createType("Balance", amount.toString());
         const currencyPair = newVaultCurrencyPair(
             this.api,
@@ -401,7 +389,7 @@ export class DefaultVaultsAPI implements VaultsAPI {
         await this.transactionAPI.sendLogged(tx, this.api.events.vaultRegistry.DepositCollateral, true);
     }
 
-    async list(atBlock?: BlockHash): Promise<VaultExt<BitcoinUnit>[]> {
+    async list(atBlock?: BlockHash): Promise<VaultExt[]> {
         const vaultsMap = await (atBlock
             ? this.api.query.vaultRegistry.vaults.entriesAt(atBlock)
             : this.api.query.vaultRegistry.vaults.entries());
@@ -415,7 +403,7 @@ export class DefaultVaultsAPI implements VaultsAPI {
     async getOrNull(
         vaultAccountId: AccountId,
         collateralCurrencyIdLiteral: CollateralIdLiteral
-    ): Promise<VaultExt<BitcoinUnit> | null> {
+    ): Promise<VaultExt | null> {
         try {
             const collateralCurrency = currencyIdLiteralToMonetaryCurrency(
                 this.api,
@@ -432,10 +420,7 @@ export class DefaultVaultsAPI implements VaultsAPI {
         }
     }
 
-    async get(
-        vaultAccountId: AccountId,
-        collateralCurrencyIdLiteral: CollateralIdLiteral
-    ): Promise<VaultExt<BitcoinUnit>> {
+    async get(vaultAccountId: AccountId, collateralCurrencyIdLiteral: CollateralIdLiteral): Promise<VaultExt> {
         const vault = await this.getOrNull(vaultAccountId, collateralCurrencyIdLiteral);
 
         if (vault === null) {
@@ -451,7 +436,7 @@ export class DefaultVaultsAPI implements VaultsAPI {
     async getCollateral(
         vaultAccountId: AccountId,
         collateralCurrencyIdLiteral: CollateralIdLiteral
-    ): Promise<MonetaryAmount<Currency<CollateralUnit>, CollateralUnit>> {
+    ): Promise<MonetaryAmount<CollateralCurrency>> {
         const collateralCurrency = currencyIdLiteralToMonetaryCurrency(
             this.api,
             collateralCurrencyIdLiteral
@@ -480,7 +465,7 @@ export class DefaultVaultsAPI implements VaultsAPI {
     async computeBackingCollateral(
         vaultId: InterbtcPrimitivesVaultId,
         nonce?: number
-    ): Promise<MonetaryAmount<Currency<CollateralUnit>, CollateralUnit>> {
+    ): Promise<MonetaryAmount<CollateralCurrency>> {
         const collateralCurrencyIdLiteral = currencyIdToLiteral(vaultId.currencies.collateral) as CollateralIdLiteral;
         if (nonce === undefined) {
             nonce = await this.rewardsAPI.getStakingPoolNonce(collateralCurrencyIdLiteral, vaultId.accountId);
@@ -488,10 +473,7 @@ export class DefaultVaultsAPI implements VaultsAPI {
 
         const rawBackingCollateral = await this.api.query.vaultStaking.totalCurrentStake(nonce, vaultId);
         const collateralCurrency = currencyIdToMonetaryCurrency(vaultId.currencies.collateral);
-        return newMonetaryAmount(
-            decodeFixedPointType(rawBackingCollateral),
-            collateralCurrency as Currency<CollateralUnit>
-        );
+        return newMonetaryAmount(decodeFixedPointType(rawBackingCollateral), collateralCurrency);
     }
 
     async backingCollateralProportion(
@@ -539,7 +521,7 @@ export class DefaultVaultsAPI implements VaultsAPI {
                 this.backingCollateralProportion(vaultAccountId, nominatorId, collateralCurrency),
                 (
                     await this.tokensAPI.balance(
-                        currencyIdToMonetaryCurrency(vault.id.currencies.collateral) as Currency<CollateralUnit>,
+                        currencyIdToMonetaryCurrency(vault.id.currencies.collateral),
                         vaultAccountId
                     )
                 ).reserved,
@@ -566,7 +548,7 @@ export class DefaultVaultsAPI implements VaultsAPI {
         collateralCurrencyId: CollateralIdLiteral,
         rewardCurrencyIdLiteral: CurrencyIdLiteral,
         nonce?: number
-    ): Promise<MonetaryAmount<Currency<CurrencyUnit>, CurrencyUnit>> {
+    ): Promise<MonetaryAmount<Currency>> {
         const [totalGlobalReward, globalRewardShare] = await Promise.all([
             this.rewardsAPI.computeRewardInRewardsPool(rewardCurrencyIdLiteral, collateralCurrencyId, vaultAccountId),
             this.backingCollateralProportion(vaultAccountId, nominatorId, collateralCurrencyId),
@@ -585,43 +567,41 @@ export class DefaultVaultsAPI implements VaultsAPI {
     async getWrappedReward(
         vaultAccountId: AccountId,
         collateralCurrency: CollateralIdLiteral
-    ): Promise<MonetaryAmount<Currency<BitcoinUnit>, BitcoinUnit>> {
-        return (await this.computeReward(
+    ): Promise<MonetaryAmount<WrappedCurrency>> {
+        return await this.computeReward(
             vaultAccountId,
             vaultAccountId,
             collateralCurrency,
             tickerToCurrencyIdLiteral(this.wrappedCurrency.ticker)
-        )) as MonetaryAmount<Currency<BitcoinUnit>, BitcoinUnit>;
+        );
     }
 
     async getGovernanceReward(
         vaultAccountId: AccountId,
         vaultCollateralIdLiteral: CollateralIdLiteral,
         governanceCurrencyIdLiteral: GovernanceIdLiteral
-    ): Promise<MonetaryAmount<Currency<GovernanceUnit>, GovernanceUnit>> {
-        return (await this.computeReward(
+    ): Promise<MonetaryAmount<GovernanceCurrency>> {
+        return await this.computeReward(
             vaultAccountId,
             vaultAccountId,
             vaultCollateralIdLiteral,
             governanceCurrencyIdLiteral
-        )) as MonetaryAmount<Currency<GovernanceUnit>, GovernanceUnit>;
+        );
     }
 
     async getStakingCapacity(
         vaultAccountId: AccountId,
         collateralCurrency: CollateralIdLiteral
-    ): Promise<MonetaryAmount<Currency<CollateralUnit>, CollateralUnit>> {
+    ): Promise<MonetaryAmount<CollateralCurrency>> {
         const vault = await this.get(vaultAccountId, collateralCurrency);
         const [collateral, maxNominationRatio] = await Promise.all([
             this.getCollateral(vaultAccountId, collateralCurrency),
-            this.getMaxNominationRatio(
-                currencyIdToMonetaryCurrency(vault.id.currencies.collateral) as CollateralCurrency
-            ),
+            this.getMaxNominationRatio(currencyIdToMonetaryCurrency(vault.id.currencies.collateral)),
         ]);
         return collateral.mul(maxNominationRatio).sub(vault.backingCollateral);
     }
 
-    async getLiquidationVault(collateralCurrency: CollateralCurrency): Promise<SystemVaultExt<BitcoinUnit>> {
+    async getLiquidationVault(collateralCurrency: CollateralCurrency): Promise<SystemVaultExt> {
         const vaultCurrencyPair = newVaultCurrencyPair(this.api, collateralCurrency, this.wrappedCurrency);
         const liquidationVault = await this.api.query.vaultRegistry.liquidationVault(vaultCurrencyPair);
         if (!liquidationVault.isSome) {
@@ -648,10 +628,10 @@ export class DefaultVaultsAPI implements VaultsAPI {
         return vaultCollateralization.lt(premiumRedeemThreshold);
     }
 
-    async getVaultCollateralization<C extends CollateralUnit>(
+    async getVaultCollateralization(
         vaultAccountId: AccountId,
         collateralCurrencyIdLiteral: CollateralIdLiteral,
-        newCollateral?: MonetaryAmount<Currency<C>, C>,
+        newCollateral?: MonetaryAmount<CollateralCurrency>,
         onlyIssued = false
     ): Promise<Big | undefined> {
         let collateralization = undefined;
@@ -689,9 +669,9 @@ export class DefaultVaultsAPI implements VaultsAPI {
         return this.getCollateralizationFromVaultAndCollateral(vaultId, collateral, onlyIssued);
     }
 
-    async getCollateralizationFromVaultAndCollateral<C extends CollateralUnit>(
+    async getCollateralizationFromVaultAndCollateral(
         vaultId: InterbtcPrimitivesVaultId,
-        newCollateral: MonetaryAmount<Currency<C>, C>,
+        newCollateral: MonetaryAmount<CollateralCurrency>,
         onlyIssued: boolean
     ): Promise<Big> {
         const vault = await this.get(
@@ -711,22 +691,20 @@ export class DefaultVaultsAPI implements VaultsAPI {
         return Promise.resolve(undefined);
     }
 
-    async getRequiredCollateralForVault<C extends CollateralUnit>(
+    async getRequiredCollateralForVault(
         vaultAccountId: AccountId,
-        currency: Currency<C>
-    ): Promise<MonetaryAmount<Currency<C>, C>> {
+        currency: CollateralCurrency
+    ): Promise<MonetaryAmount<CollateralCurrency>> {
         const vault = await this.get(vaultAccountId, tickerToCurrencyIdLiteral(currency.ticker) as CollateralIdLiteral);
         const issuedTokens = vault.getBackedTokens();
         return await this.getRequiredCollateralForWrapped(issuedTokens, currency);
     }
 
-    async getRequiredCollateralForWrapped<C extends CollateralUnit>(
-        wrappedAmount: MonetaryAmount<Currency<BitcoinUnit>, BitcoinUnit>,
-        currency: Currency<C>
-    ): Promise<MonetaryAmount<Currency<C>, C>> {
-        const secureCollateralThreshold = await this.getSecureCollateralThreshold(
-            currency as unknown as CollateralCurrency
-        );
+    async getRequiredCollateralForWrapped(
+        wrappedAmount: MonetaryAmount<WrappedCurrency>,
+        currency: CollateralCurrency
+    ): Promise<MonetaryAmount<CollateralCurrency>> {
+        const secureCollateralThreshold = await this.getSecureCollateralThreshold(currency);
         const requiredCollateralInWrappedCurrency = wrappedAmount.mul(secureCollateralThreshold);
         return await this.oracleAPI.convertWrappedToCurrency(requiredCollateralInWrappedCurrency, currency);
     }
@@ -734,17 +712,17 @@ export class DefaultVaultsAPI implements VaultsAPI {
     async getIssuedAmount(
         vaultAccountId: AccountId,
         collateralCurrency: CollateralIdLiteral
-    ): Promise<MonetaryAmount<Currency<BitcoinUnit>, BitcoinUnit>> {
+    ): Promise<MonetaryAmount<WrappedCurrency>> {
         const vault = await this.get(vaultAccountId, collateralCurrency);
         return vault.issuedTokens;
     }
 
-    async getTotalIssuedAmount(): Promise<MonetaryAmount<WrappedCurrency, BitcoinUnit>> {
+    async getTotalIssuedAmount(): Promise<MonetaryAmount<WrappedCurrency>> {
         const issuedTokens = await this.tokensAPI.total(this.wrappedCurrency);
         return issuedTokens;
     }
 
-    async getTotalIssuableAmount(): Promise<MonetaryAmount<WrappedCurrency, BitcoinUnit>> {
+    async getTotalIssuableAmount(): Promise<MonetaryAmount<WrappedCurrency>> {
         // get [[wrapped, collateral], amount][] map
         const perCurrencyPairCollateralAmounts = await this.api.query.vaultRegistry.totalUserVaultCollateral.entries();
         // filter for wrapped === this.wrapped, as only one wrapped currency is handled at a time currently
@@ -754,7 +732,7 @@ export class DefaultVaultsAPI implements VaultsAPI {
         // reduce from [[this.wrapped, collateral], amount][] pairs to [collateral, sumAmount][] map
         const perCollateralCurrencyCollateralAmounts = perWrappedCurrencyCollateralAmounts.reduce(
             (amounts, [key, amount]) => {
-                const collateralCurrency = currencyIdToMonetaryCurrency<CollateralUnit>(key.args[0].collateral);
+                const collateralCurrency = currencyIdToMonetaryCurrency(key.args[0].collateral);
                 let collateralAmount = newMonetaryAmount(amount.toString(), collateralCurrency);
                 if (amounts.has(collateralCurrency)) {
                     // .has() is true, hence non-null
@@ -764,7 +742,7 @@ export class DefaultVaultsAPI implements VaultsAPI {
                 amounts.set(collateralCurrency, collateralAmount);
                 return amounts;
             },
-            new Map<Currency<CollateralUnit>, MonetaryAmount<Currency<CollateralUnit>, CollateralUnit>>()
+            new Map<CollateralCurrency, MonetaryAmount<CollateralCurrency>>()
         );
         // finally convert the CollateralAmount sums to issuable amounts and sum those to get the total
         const [perCollateralCurrencyIssuableAmounts, issuedAmountBtc] = await Promise.all([
@@ -779,9 +757,7 @@ export class DefaultVaultsAPI implements VaultsAPI {
         return totalIssuableAmount.sub(issuedAmountBtc);
     }
 
-    async calculateCapacity<C extends CollateralUnit>(
-        collateral: MonetaryAmount<Currency<C>, C>
-    ): Promise<MonetaryAmount<Currency<BitcoinUnit>, BitcoinUnit>> {
+    async calculateCapacity(collateral: MonetaryAmount<CollateralCurrency>): Promise<MonetaryAmount<WrappedCurrency>> {
         try {
             const [exchangeRate, secureCollateralThreshold] = await Promise.all([
                 this.oracleAPI.getExchangeRate(collateral.currency),
@@ -794,9 +770,7 @@ export class DefaultVaultsAPI implements VaultsAPI {
         }
     }
 
-    async selectRandomVaultIssue(
-        amount: MonetaryAmount<WrappedCurrency, BitcoinUnit>
-    ): Promise<InterbtcPrimitivesVaultId> {
+    async selectRandomVaultIssue(amount: MonetaryAmount<WrappedCurrency>): Promise<InterbtcPrimitivesVaultId> {
         const vaults = await this.getVaultsWithIssuableTokens();
         for (const [id, issuableAmount] of vaults) {
             if (issuableAmount.gte(amount)) {
@@ -806,9 +780,7 @@ export class DefaultVaultsAPI implements VaultsAPI {
         return Promise.reject(new Error("Did not find vault with sufficient collateral"));
     }
 
-    async selectRandomVaultRedeem(
-        amount: MonetaryAmount<WrappedCurrency, BitcoinUnit>
-    ): Promise<InterbtcPrimitivesVaultId> {
+    async selectRandomVaultRedeem(amount: MonetaryAmount<WrappedCurrency>): Promise<InterbtcPrimitivesVaultId> {
         // Selects the first vault with sufficient tokens
         const vaults = await this.list();
         for (const vault of vaults) {
@@ -819,10 +791,8 @@ export class DefaultVaultsAPI implements VaultsAPI {
         return Promise.reject(new Error("Did not find vault with sufficient locked BTC"));
     }
 
-    async getPremiumRedeemVaults(): Promise<
-        Map<InterbtcPrimitivesVaultId, MonetaryAmount<Currency<BitcoinUnit>, BitcoinUnit>>
-    > {
-        const map: Map<InterbtcPrimitivesVaultId, MonetaryAmount<WrappedCurrency, BitcoinUnit>> = new Map();
+    async getPremiumRedeemVaults(): Promise<Map<InterbtcPrimitivesVaultId, MonetaryAmount<WrappedCurrency>>> {
+        const map: Map<InterbtcPrimitivesVaultId, MonetaryAmount<WrappedCurrency>> = new Map();
         const vaults = await this.getVaultsEligibleForRedeeming();
 
         const premiumRedeemVaultPredicates = await Promise.all(
@@ -834,10 +804,8 @@ export class DefaultVaultsAPI implements VaultsAPI {
         return map;
     }
 
-    async getVaultsWithIssuableTokens(): Promise<
-        Map<InterbtcPrimitivesVaultId, MonetaryAmount<Currency<BitcoinUnit>, BitcoinUnit>>
-    > {
-        const map: Map<InterbtcPrimitivesVaultId, MonetaryAmount<WrappedCurrency, BitcoinUnit>> = new Map();
+    async getVaultsWithIssuableTokens(): Promise<Map<InterbtcPrimitivesVaultId, MonetaryAmount<WrappedCurrency>>> {
+        const map: Map<InterbtcPrimitivesVaultId, MonetaryAmount<WrappedCurrency>> = new Map();
         const [vaults, activeBlockNumber] = await Promise.all([
             this.list(),
             this.systemAPI.getCurrentActiveBlockNumber(),
@@ -849,8 +817,8 @@ export class DefaultVaultsAPI implements VaultsAPI {
                     return vault.status === VaultStatusExt.Active && bannedUntilBlockNumber < activeBlockNumber;
                 })
                 .map((vault) => {
-                    return new Promise<[MonetaryAmount<Currency<BitcoinUnit>, BitcoinUnit>, InterbtcPrimitivesVaultId]>(
-                        (resolve, _) => vault.getIssuableTokens().then((amount) => resolve([amount, vault.id]))
+                    return new Promise<[MonetaryAmount<WrappedCurrency>, InterbtcPrimitivesVaultId]>((resolve, _) =>
+                        vault.getIssuableTokens().then((amount) => resolve([amount, vault.id]))
                     );
                 })
         );
@@ -858,7 +826,7 @@ export class DefaultVaultsAPI implements VaultsAPI {
         return map;
     }
 
-    private isVaultEligibleForRedeem(vault: VaultExt<BitcoinUnit>, activeBlockNumber: number): boolean {
+    private isVaultEligibleForRedeem(vault: VaultExt, activeBlockNumber: number): boolean {
         const bannedUntilBlockNumber = vault.bannedUntil || 0;
         return (
             (vault.status === VaultStatusExt.Active || vault.status === VaultStatusExt.Inactive) &&
@@ -867,7 +835,7 @@ export class DefaultVaultsAPI implements VaultsAPI {
         );
     }
 
-    private async getVaultsEligibleForRedeeming(): Promise<VaultExt<BitcoinUnit>[]> {
+    private async getVaultsEligibleForRedeeming(): Promise<VaultExt[]> {
         const [vaults, activeBlockNumber] = await Promise.all([
             this.list(),
             this.systemAPI.getCurrentActiveBlockNumber(),
@@ -881,10 +849,8 @@ export class DefaultVaultsAPI implements VaultsAPI {
         return redeemVaults;
     }
 
-    async getVaultsWithRedeemableTokens(): Promise<
-        Map<InterbtcPrimitivesVaultId, MonetaryAmount<WrappedCurrency, BitcoinUnit>>
-    > {
-        const map: Map<InterbtcPrimitivesVaultId, MonetaryAmount<WrappedCurrency, BitcoinUnit>> = new Map();
+    async getVaultsWithRedeemableTokens(): Promise<Map<InterbtcPrimitivesVaultId, MonetaryAmount<WrappedCurrency>>> {
+        const map: Map<InterbtcPrimitivesVaultId, MonetaryAmount<WrappedCurrency>> = new Map();
         const vaults = await this.getVaultsEligibleForRedeeming();
         vaults
             .sort((vault1, vault2) => {
@@ -934,7 +900,7 @@ export class DefaultVaultsAPI implements VaultsAPI {
             await this.getWrappedReward(vaultAccountId, collateralCurrency),
             (
                 await this.tokensAPI.balance(
-                    currencyIdToMonetaryCurrency(vault.id.currencies.collateral) as Currency<CollateralUnit>,
+                    currencyIdToMonetaryCurrency(vault.id.currencies.collateral),
                     vaultAccountId
                 )
             ).reserved,
@@ -953,14 +919,14 @@ export class DefaultVaultsAPI implements VaultsAPI {
         return decodeFixedPointType(fee);
     }
 
-    private wrapCurrency<C extends CollateralUnit>(amount: MonetaryAmount<Currency<C>, C>): BalanceWrapper {
+    private wrapCurrency(amount: MonetaryAmount<CollateralCurrency>): BalanceWrapper {
         return this.api.createType("BalanceWrapper", {
             amount: this.api.createType("u128", amount.toString()),
             currencyId: newCurrencyId(this.api, tickerToCurrencyIdLiteral(amount.currency.ticker)),
         });
     }
 
-    private unwrapCurrency<C extends CollateralUnit>(wrappedBalance: BalanceWrapper): MonetaryAmount<Currency<C>, C> {
+    private unwrapCurrency(wrappedBalance: BalanceWrapper): MonetaryAmount<CollateralCurrency> {
         return newMonetaryAmount(
             wrappedBalance.amount.toString(),
             currencyIdToMonetaryCurrency(wrappedBalance.currencyId)
@@ -979,12 +945,12 @@ export class DefaultVaultsAPI implements VaultsAPI {
         }
     }
 
-    async parseVault(vault: VaultRegistryVault, network: Network): Promise<VaultExt<BitcoinUnit>> {
-        const collateralCurrency = currencyIdToMonetaryCurrency<CollateralUnit>(vault.id.currencies.collateral);
+    async parseVault(vault: VaultRegistryVault, network: Network): Promise<VaultExt> {
+        const collateralCurrency = currencyIdToMonetaryCurrency(vault.id.currencies.collateral);
         const replaceCollateral = newMonetaryAmount(vault.replaceCollateral.toString(), collateralCurrency);
         const liquidatedCollateral = newMonetaryAmount(vault.liquidatedCollateral.toString(), collateralCurrency);
         const backingCollateral = await this.computeBackingCollateral(vault.id);
-        return new VaultExt<BitcoinUnit>(
+        return new VaultExt(
             this.api,
             this.oracleAPI,
             this.systemAPI,

--- a/src/types/oracleTypes.ts
+++ b/src/types/oracleTypes.ts
@@ -1,19 +1,14 @@
-import { Bitcoin, BitcoinUnit, Currency, ExchangeRate, Polkadot, PolkadotUnit, UnitList } from "@interlay/monetary-js";
+import { Bitcoin, Currency, ExchangeRate, Polkadot } from "@interlay/monetary-js";
 
-export interface OracleStatus<
-    B extends Currency<BaseUnit>,
-    BaseUnit extends UnitList,
-    C extends Currency<CounterUnit>,
-    CounterUnit extends UnitList
-> {
+export interface OracleStatus<B extends Currency, C extends Currency> {
     id: string;
     source: string;
     feed: string;
     lastUpdate: Date;
-    exchangeRate: ExchangeRate<B, BaseUnit, C, CounterUnit>;
+    exchangeRate: ExchangeRate<B, C>;
     online: boolean;
 }
 
-export type DOTBTCOracleStatus = OracleStatus<Bitcoin, BitcoinUnit, Polkadot, PolkadotUnit>;
+export type DOTBTCOracleStatus = OracleStatus<Bitcoin, Polkadot>;
 
 export type FeeEstimationType = "Fast" | "Half" | "Hour";

--- a/src/types/requestTypes.ts
+++ b/src/types/requestTypes.ts
@@ -1,15 +1,14 @@
-import { MonetaryAmount } from "@interlay/monetary-js";
+import { Bitcoin, MonetaryAmount } from "@interlay/monetary-js";
 import { AccountId } from "@polkadot/types/interfaces";
-import { CollateralUnit, WrappedCurrency } from "../types";
-import { BitcoinUnit, Currency } from "@interlay/monetary-js";
+import { CollateralCurrency, WrappedCurrency } from "../types";
 import { InterbtcPrimitivesVaultId, InterbtcPrimitivesReplaceReplaceRequestStatus } from "@polkadot/types/lookup";
 
 export interface Issue {
     id: string;
-    wrappedAmount: MonetaryAmount<WrappedCurrency, BitcoinUnit>;
+    wrappedAmount: MonetaryAmount<WrappedCurrency>;
     userParachainAddress: string;
-    bridgeFee: MonetaryAmount<WrappedCurrency, BitcoinUnit>;
-    griefingCollateral: MonetaryAmount<Currency<CollateralUnit>, CollateralUnit>;
+    bridgeFee: MonetaryAmount<WrappedCurrency>;
+    griefingCollateral: MonetaryAmount<CollateralCurrency>;
     vaultWalletPubkey: string;
     creationBlock: number;
     creationTimestamp?: number;
@@ -19,11 +18,11 @@ export interface Issue {
     confirmations?: number;
     btcBlockHeight?: number;
     btcConfirmationActiveBlockHeight?: number;
-    btcAmountSubmittedByUser?: MonetaryAmount<WrappedCurrency, BitcoinUnit>;
+    btcAmountSubmittedByUser?: MonetaryAmount<WrappedCurrency>;
     status: IssueStatus;
     refundBtcAddress?: string;
-    refundAmountWrapped?: MonetaryAmount<WrappedCurrency, BitcoinUnit>;
-    executedAmountWrapped?: MonetaryAmount<WrappedCurrency, BitcoinUnit>;
+    refundAmountWrapped?: MonetaryAmount<WrappedCurrency>;
+    executedAmountWrapped?: MonetaryAmount<WrappedCurrency>;
     period: number;
 }
 
@@ -47,10 +46,10 @@ export enum NominationStatus {
 export interface Redeem {
     id: string;
     userParachainAddress: string;
-    amountBTC: MonetaryAmount<WrappedCurrency, BitcoinUnit>;
-    collateralPremium: MonetaryAmount<Currency<CollateralUnit>, CollateralUnit>;
-    bridgeFee: MonetaryAmount<WrappedCurrency, BitcoinUnit>;
-    btcTransferFee: MonetaryAmount<WrappedCurrency, BitcoinUnit>;
+    amountBTC: MonetaryAmount<WrappedCurrency>;
+    collateralPremium: MonetaryAmount<CollateralCurrency>;
+    bridgeFee: MonetaryAmount<WrappedCurrency>;
+    btcTransferFee: MonetaryAmount<Bitcoin>;
     creationTimestamp?: number;
     creationBlock: number;
     vaultId: InterbtcPrimitivesVaultId;
@@ -75,9 +74,9 @@ export enum RedeemStatus {
 
 export interface RefundRequestExt {
     vaultId: InterbtcPrimitivesVaultId;
-    amountIssuing: MonetaryAmount<WrappedCurrency, BitcoinUnit>;
-    fee: MonetaryAmount<WrappedCurrency, BitcoinUnit>;
-    amountBtc: MonetaryAmount<WrappedCurrency, BitcoinUnit>;
+    amountIssuing: MonetaryAmount<WrappedCurrency>;
+    fee: MonetaryAmount<WrappedCurrency>;
+    amountBtc: MonetaryAmount<Bitcoin>;
     issuer: AccountId;
     btcAddress: string;
     issueId: string;
@@ -89,9 +88,9 @@ export interface ReplaceRequestExt {
     btcAddress: string;
     newVault: InterbtcPrimitivesVaultId;
     oldVault: InterbtcPrimitivesVaultId;
-    amount: MonetaryAmount<WrappedCurrency, BitcoinUnit>;
-    griefingCollateral: MonetaryAmount<Currency<CollateralUnit>, CollateralUnit>;
-    collateral: MonetaryAmount<Currency<CollateralUnit>, CollateralUnit>;
+    amount: MonetaryAmount<WrappedCurrency>;
+    griefingCollateral: MonetaryAmount<CollateralCurrency>;
+    collateral: MonetaryAmount<CollateralCurrency>;
     acceptTime: number;
     period: number;
     btcHeight: number;

--- a/src/utils/bitcoin-core-client.ts
+++ b/src/utils/bitcoin-core-client.ts
@@ -3,7 +3,6 @@
 import { MonetaryAmount } from "@interlay/monetary-js";
 import Big from "big.js";
 import { WrappedCurrency } from "../types";
-import { ATOMIC_UNIT } from "./currency";
 
 // eslint-disable-next-line
 const Client = require("bitcoin-core");
@@ -72,7 +71,7 @@ export class BitcoinCoreClient {
         const raw = await this.client.command(
             "createrawtransaction",
             [],
-            this.formatRawTxInput(recipient, amount.toBig(ATOMIC_UNIT), data)
+            this.formatRawTxInput(recipient, amount.toBig(), data)
         );
         const funded = await this.client.command("fundrawtransaction", raw);
         const signed = await this.client.command("signrawtransactionwithwallet", funded.hex);

--- a/src/utils/bitcoin-core-client.ts
+++ b/src/utils/bitcoin-core-client.ts
@@ -1,8 +1,9 @@
 // disabling linting as `bitcoin-core` has no types, causing the import to fail
 
-import { BitcoinUnit, Bitcoin, MonetaryAmount } from "@interlay/monetary-js";
+import { MonetaryAmount } from "@interlay/monetary-js";
 import Big from "big.js";
 import { WrappedCurrency } from "../types";
+import { ATOMIC_UNIT } from "./currency";
 
 // eslint-disable-next-line
 const Client = require("bitcoin-core");
@@ -34,7 +35,7 @@ export class BitcoinCoreClient {
 
     async sendBtcTxAndMine(
         recipient: string,
-        amount: MonetaryAmount<WrappedCurrency, BitcoinUnit>,
+        amount: MonetaryAmount<WrappedCurrency>,
         blocksToMine: number,
         data?: string
     ): Promise<{
@@ -58,7 +59,7 @@ export class BitcoinCoreClient {
 
     async broadcastTx(
         recipient: string,
-        amount: MonetaryAmount<WrappedCurrency, BitcoinUnit>,
+        amount: MonetaryAmount<WrappedCurrency>,
         data?: string
     ): Promise<{
         txid: string;
@@ -67,11 +68,11 @@ export class BitcoinCoreClient {
         if (!this.client) {
             throw new Error("Client needs to be initialized before usage");
         }
-        console.log(`Broadcasting tx: ${amount.toString(Bitcoin.base)} BTC to ${recipient}`);
+        console.log(`Broadcasting tx: ${amount.toString()} BTC to ${recipient}`);
         const raw = await this.client.command(
             "createrawtransaction",
             [],
-            this.formatRawTxInput(recipient, amount.toBig(Bitcoin.units.BTC), data)
+            this.formatRawTxInput(recipient, amount.toBig(ATOMIC_UNIT), data)
         );
         const funded = await this.client.command("fundrawtransaction", raw);
         const signed = await this.client.command("signrawtransactionwithwallet", funded.hex);
@@ -93,8 +94,8 @@ export class BitcoinCoreClient {
         return await this.client.command("getbalance");
     }
 
-    async sendToAddress(address: string, amount: MonetaryAmount<WrappedCurrency, BitcoinUnit>): Promise<string> {
-        return await this.client.command("sendtoaddress", address, amount.toString(Bitcoin.units.BTC));
+    async sendToAddress(address: string, amount: MonetaryAmount<WrappedCurrency>): Promise<string> {
+        return await this.client.command("sendtoaddress", address, amount.toString());
     }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/utils/encoding.ts
+++ b/src/utils/encoding.ts
@@ -5,7 +5,6 @@ import type { Struct } from "@polkadot/types";
 import { Network } from "bitcoinjs-lib";
 import { StorageKey } from "@polkadot/types/primitive/StorageKey";
 import { Codec } from "@polkadot/types/types";
-import { BitcoinUnit, Currency } from "@interlay/monetary-js";
 import { Moment } from "@polkadot/types/interfaces";
 import { Option } from "@polkadot/types/codec";
 import { Bytes } from "@polkadot/types-codec";
@@ -29,7 +28,6 @@ import { SignedFixedPoint, UnsignedFixedPoint } from "../interfaces";
 import {
     CollateralCurrency,
     CollateralIdLiteral,
-    CollateralUnit,
     CurrencyIdLiteral,
     currencyIdToLiteral,
     currencyIdToMonetaryCurrency,
@@ -164,12 +162,12 @@ export function parseSystemVault(
     vault: VaultRegistrySystemVault,
     wrappedCurrency: WrappedCurrency,
     collateralCurrency: CollateralCurrency
-): SystemVaultExt<BitcoinUnit> {
+): SystemVaultExt {
     return {
         toBeIssuedTokens: newMonetaryAmount(vault.toBeIssuedTokens.toString(), wrappedCurrency),
         issuedTokens: newMonetaryAmount(vault.issuedTokens.toString(), wrappedCurrency),
         toBeRedeemedTokens: newMonetaryAmount(vault.toBeRedeemedTokens.toString(), wrappedCurrency),
-        collateral: newMonetaryAmount(vault.collateral.toString(), collateralCurrency as Currency<CollateralUnit>),
+        collateral: newMonetaryAmount(vault.collateral.toString(), collateralCurrency),
         currencyPair: {
             collateralCurrency: currencyIdToMonetaryCurrency(vault.currencyPair.collateral),
             wrappedCurrency: currencyIdToMonetaryCurrency(vault.currencyPair.wrapped),
@@ -237,9 +235,7 @@ export async function parseReplaceRequest(
 ): Promise<ReplaceRequestExt> {
     const currencyIdLiteral = currencyIdToLiteral(req.oldVault.currencies.collateral);
     const oldVault = await vaultsAPI.get(req.oldVault.accountId, currencyIdLiteral);
-    const collateralCurrency = currencyIdToMonetaryCurrency(
-        oldVault.id.currencies.collateral
-    ) as Currency<CollateralUnit>;
+    const collateralCurrency = currencyIdToMonetaryCurrency(oldVault.id.currencies.collateral);
     return {
         id: stripHexPrefix(id.toString()),
         btcAddress: encodeBtcAddress(req.btcAddress, network),
@@ -266,9 +262,7 @@ export async function parseIssueRequest(
         : req.status.isCancelled
         ? IssueStatus.Cancelled
         : IssueStatus.PendingWithBtcTxNotFound;
-    const collateralCurrency = currencyIdToMonetaryCurrency(
-        req.vault.currencies.collateral
-    ) as Currency<CollateralUnit>;
+    const collateralCurrency = currencyIdToMonetaryCurrency(req.vault.currencies.collateral);
     return {
         id: stripHexPrefix(id.toString()),
         creationBlock: req.opentime.toNumber(),
@@ -300,7 +294,7 @@ export async function parseRedeemRequest(
 
     const currencyIdLiteral = currencyIdToLiteral(req.vault.currencies.collateral);
     const vault = await vaultsAPI.get(req.vault.accountId, currencyIdLiteral);
-    const collateralCurrency = currencyIdToMonetaryCurrency(vault.id.currencies.collateral) as Currency<CollateralUnit>;
+    const collateralCurrency = currencyIdToMonetaryCurrency(vault.id.currencies.collateral);
     return {
         id: stripHexPrefix(id.toString()),
         userParachainAddress: req.redeemer.toString(),

--- a/src/utils/issueRedeem.ts
+++ b/src/utils/issueRedeem.ts
@@ -3,7 +3,7 @@ import { ApiTypes, AugmentedEvent } from "@polkadot/api/types";
 import type { AnyTuple } from "@polkadot/types/types";
 import { ApiPromise } from "@polkadot/api";
 import { KeyringPair } from "@polkadot/keyring/types";
-import { BitcoinAmount, BitcoinUnit, Currency, InterBtcAmount, MonetaryAmount } from "@interlay/monetary-js";
+import { Bitcoin, BitcoinAmount, InterBtcAmount, MonetaryAmount } from "@interlay/monetary-js";
 import { InterbtcPrimitivesVaultId } from "@polkadot/types/lookup";
 
 import { newAccountId } from "../utils";
@@ -11,15 +11,15 @@ import { BitcoinCoreClient } from "./bitcoin-core-client";
 import { stripHexPrefix } from "../utils/encoding";
 import { currencyIdToLiteral, Issue, IssueStatus, Redeem, RedeemStatus, WrappedCurrency } from "../types";
 import { waitForBlockFinalization } from "./bitcoin";
-import { newMonetaryAmount } from "./currency";
+import { atomicToBaseAmount, newMonetaryAmount } from "./currency";
 import { InterBtcApi } from "..";
 
 export const SLEEP_TIME_MS = 1000;
 
-export interface IssueResult<U extends BitcoinUnit> {
+export interface IssueResult {
     request: Issue;
-    initialWrappedTokenBalance: MonetaryAmount<Currency<U>, U>;
-    finalWrappedTokenBalance: MonetaryAmount<Currency<U>, U>;
+    initialWrappedTokenBalance: MonetaryAmount<WrappedCurrency>;
+    finalWrappedTokenBalance: MonetaryAmount<WrappedCurrency>;
 }
 
 export enum ExecuteRedeem {
@@ -60,12 +60,12 @@ export function getRequestIdsFromEvents(
  * with highest available amount and tries again for the remainder. If at leaast
  * one vault can fulfil a request alone, a random one among them is selected.
  **/
-export function allocateAmountsToVaults<U extends BitcoinUnit>(
-    vaultsWithAvailableAmounts: Map<InterbtcPrimitivesVaultId, MonetaryAmount<Currency<U>, U>>,
-    amountToAllocate: MonetaryAmount<Currency<U>, U>
-): Map<InterbtcPrimitivesVaultId, MonetaryAmount<Currency<U>, U>> {
+export function allocateAmountsToVaults(
+    vaultsWithAvailableAmounts: Map<InterbtcPrimitivesVaultId, MonetaryAmount<WrappedCurrency>>,
+    amountToAllocate: MonetaryAmount<WrappedCurrency>
+): Map<InterbtcPrimitivesVaultId, MonetaryAmount<WrappedCurrency>> {
     const maxReservationPercent = 95; // don't reserve more than 95% of a vault's collateral
-    const allocations = new Map<InterbtcPrimitivesVaultId, MonetaryAmount<Currency<U>, U>>();
+    const allocations = new Map<InterbtcPrimitivesVaultId, MonetaryAmount<WrappedCurrency>>();
     // iterable array in ascending order of issuing capacity:
     const vaultsArray = [...vaultsWithAvailableAmounts.entries()]
         .reverse()
@@ -73,7 +73,7 @@ export function allocateAmountsToVaults<U extends BitcoinUnit>(
             (entry) =>
                 [entry[0], entry[1].div(100).mul(maxReservationPercent)] as [
                     InterbtcPrimitivesVaultId,
-                    MonetaryAmount<Currency<U>, U>
+                    MonetaryAmount<WrappedCurrency>
                 ]
         );
     while (amountToAllocate.gt(newMonetaryAmount(0, amountToAllocate.currency))) {
@@ -104,12 +104,12 @@ export async function issueSingle(
     interBtcApi: InterBtcApi,
     bitcoinCoreClient: BitcoinCoreClient,
     issuingAccount: KeyringPair,
-    amount: MonetaryAmount<WrappedCurrency, BitcoinUnit>,
+    amount: MonetaryAmount<WrappedCurrency>,
     vaultId?: InterbtcPrimitivesVaultId,
     autoExecute = true,
     triggerRefund = false,
     atomic = true
-): Promise<IssueResult<BitcoinUnit>> {
+): Promise<IssueResult> {
     const prevAccount = interBtcApi.account;
     interBtcApi.setAccount(issuingAccount);
     try {
@@ -132,11 +132,12 @@ export async function issueSingle(
         let amountAsBtc = issueRequest.wrappedAmount.add(issueRequest.bridgeFee);
         if (triggerRefund) {
             // Send 1 more Btc than needed
-            amountAsBtc = amountAsBtc.add(BitcoinAmount.from.BTC(1));
+            amountAsBtc = amountAsBtc.add(new BitcoinAmount(1));
         } else if (autoExecute === false) {
             // Send 1 less Satoshi than requested
             // to trigger the user failsafe and disable auto-execution.
-            const oneSatoshi = BitcoinAmount.from.Satoshi(1);
+            const oneSatoshiInBtc = atomicToBaseAmount(1, Bitcoin);
+            const oneSatoshi = new BitcoinAmount(oneSatoshiInBtc);
             amountAsBtc = amountAsBtc.sub(oneSatoshi);
         }
 
@@ -185,7 +186,7 @@ export async function redeem(
     interBtcApi: InterBtcApi,
     bitcoinCoreClient: BitcoinCoreClient,
     redeemingAccount: KeyringPair,
-    amount: MonetaryAmount<WrappedCurrency, BitcoinUnit>,
+    amount: MonetaryAmount<WrappedCurrency>,
     vaultId?: InterbtcPrimitivesVaultId,
     autoExecute = ExecuteRedeem.Auto,
     atomic = true,
@@ -229,8 +230,8 @@ export async function issueAndRedeem(
     bitcoinCoreClient: BitcoinCoreClient,
     account: KeyringPair,
     vaultId?: InterbtcPrimitivesVaultId,
-    issueAmount: MonetaryAmount<WrappedCurrency, BitcoinUnit> = InterBtcAmount.from.BTC(0.1),
-    redeemAmount: MonetaryAmount<WrappedCurrency, BitcoinUnit> = InterBtcAmount.from.BTC(0.009),
+    issueAmount: MonetaryAmount<WrappedCurrency> = new InterBtcAmount(0.1),
+    redeemAmount: MonetaryAmount<WrappedCurrency> = new InterBtcAmount(0.009),
     autoExecuteIssue = true,
     autoExecuteRedeem = ExecuteRedeem.Auto,
     triggerRefund = false,

--- a/src/utils/rewards.ts
+++ b/src/utils/rewards.ts
@@ -1,22 +1,22 @@
-import { GovernanceCurrency, GovernanceUnit, StakedBalance } from "../types";
+import { GovernanceCurrency, StakedBalance } from "../types";
 import Big from "big.js";
-import { Currency, MonetaryAmount } from "@interlay/monetary-js";
-import { newMonetaryAmount } from "./currency";
+import { MonetaryAmount } from "@interlay/monetary-js";
+import { ATOMIC_UNIT, newMonetaryAmount } from "./currency";
 
 // TODO: simplify this, perhaps use builder?
-export function estimateReward<U extends GovernanceUnit>(
+export function estimateReward(
     governanceCurrency: GovernanceCurrency,
-    userStake: Big,
-    totalStake: Big,
-    blockReward: MonetaryAmount<Currency<GovernanceUnit>, GovernanceUnit>,
-    stakedBalance: StakedBalance<GovernanceUnit>,
+    atomicUserStake: Big,
+    atomicTotalStake: Big,
+    blockReward: MonetaryAmount<GovernanceCurrency>,
+    stakedBalance: StakedBalance,
     currentBlockNumber: number,
     minimumBlockPeriod: number,
     maxPeriod: number,
-    amountToLock: MonetaryAmount<Currency<U>, U> = newMonetaryAmount(0, governanceCurrency as unknown as Currency<U>),
+    amountToLock: MonetaryAmount<GovernanceCurrency> = newMonetaryAmount(0, governanceCurrency),
     blockLockTimeExtension: number = 0
 ): {
-    amount: MonetaryAmount<Currency<U>, U>;
+    amount: MonetaryAmount<GovernanceCurrency>;
     apy: Big;
 } {
     // Note: the parachain uses the balance_at which combines the staked amount
@@ -36,7 +36,7 @@ export function estimateReward<U extends GovernanceUnit>(
         endBlock: stakedBalance.endBlock,
     };
 
-    const monetaryAddedStake = newMonetaryAmount(amountToLock.toBig(), governanceCurrency as Currency<GovernanceUnit>);
+    const monetaryAddedStake = newMonetaryAmount(amountToLock.toBig(ATOMIC_UNIT), governanceCurrency);
 
     // User staking for the first time; only case 2 relevant otherwise rewards should be 0
     if (stakedBalance.amount.isZero()) {
@@ -53,29 +53,32 @@ export function estimateReward<U extends GovernanceUnit>(
         newLockDuration = newStakedBalance.endBlock - currentBlockNumber;
     }
 
-    const newUserStake = newStakedBalance.amount.toBig().mul(newLockDuration).div(maxPeriod);
-    const userStakeDifference = newUserStake.sub(userStake);
-    const newTotalStake = totalStake.add(userStakeDifference);
+    const atomicNewUserStake = newStakedBalance.amount.toBig(ATOMIC_UNIT).mul(newLockDuration).div(maxPeriod);
+    const atomicUserStakeDifference = atomicNewUserStake.sub(atomicUserStake);
+    const atomicNewTotalStake = atomicTotalStake.add(atomicUserStakeDifference);
 
     // Catch 0 values
-    if (newLockDuration == 0 || newTotalStake.eq(0) || newStakedBalance.amount.isZero()) {
+    if (newLockDuration == 0 || atomicNewTotalStake.eq(0) || newStakedBalance.amount.isZero()) {
         return {
-            amount: newMonetaryAmount(0, governanceCurrency as unknown as Currency<U>),
+            amount: newMonetaryAmount(0, governanceCurrency),
             apy: new Big(0),
         };
     }
     // Reward amount for the entire time is the newUserStake / netTotalStake * blockReward * lock duration
-    const rewardAmount = newUserStake.div(newTotalStake).mul(blockReward.toBig()).mul(newLockDuration);
+    const atomicRewardAmount = atomicNewUserStake
+        .div(atomicNewTotalStake)
+        .mul(blockReward.toBig(ATOMIC_UNIT))
+        .mul(newLockDuration);
 
-    const monetaryRewardAmount = newMonetaryAmount(rewardAmount, governanceCurrency as unknown as Currency<U>);
+    const monetaryRewardAmount = newMonetaryAmount(atomicRewardAmount, governanceCurrency);
 
     // TODO: move this to a util function so we can use it across the codebase
     // normalize APY to 1 year
     const blockTime = minimumBlockPeriod * 2; // ms
     const blocksPerYear = (60 * 60 * 24 * 365 * 1000) / blockTime;
-    const annualisedReward = rewardAmount.div(newLockDuration).mul(blocksPerYear);
+    const atomicAnnualisedReward = atomicRewardAmount.div(newLockDuration).mul(blocksPerYear);
 
-    const apy = annualisedReward.div(newStakedBalance.amount.toBig()).mul(100);
+    const apy = atomicAnnualisedReward.div(newStakedBalance.amount.toBig(ATOMIC_UNIT)).mul(100);
 
     return {
         amount: monetaryRewardAmount,

--- a/test/integration/external/staging/electrs.test.ts
+++ b/test/integration/external/staging/electrs.test.ts
@@ -43,7 +43,7 @@ describe("ElectrsAPI regtest", function () {
     it("should getTxIdByRecipientAddress", async () => {
         await runWhileMiningBTCBlocks(bitcoinCoreClient, async () => {
             const recipientAddress = makeRandomBitcoinAddress();
-            const amount = BitcoinAmount.from.BTC(0.00022244);
+            const amount = new BitcoinAmount(0.00022244);
 
             const txData = await bitcoinCoreClient.broadcastTx(recipientAddress, amount);
             const txid = await waitSuccess(() =>
@@ -57,7 +57,7 @@ describe("ElectrsAPI regtest", function () {
         await runWhileMiningBTCBlocks(bitcoinCoreClient, async () => {
             const opReturnValue = "01234567891154267bf7d05901cc8c2f647414a42126c3aee89e01a2c905ae91";
             const recipientAddress = makeRandomBitcoinAddress();
-            const amount = BitcoinAmount.from.BTC(0.00029);
+            const amount = new BitcoinAmount(0.00029);
 
             const txData = await bitcoinCoreClient.broadcastTx(recipientAddress, amount, opReturnValue);
             const txid = await waitSuccess(() => electrsAPI.getTxIdByOpReturn(opReturnValue, recipientAddress, amount));
@@ -69,7 +69,7 @@ describe("ElectrsAPI regtest", function () {
         await runWhileMiningBTCBlocks(bitcoinCoreClient, async () => {
             const opReturnValue = "01234567891154267bf7d05901cc8c2f647414a42126c3aee89e01a2c905ae91";
             const recipientAddress = makeRandomBitcoinAddress();
-            const amount = BitcoinAmount.from.BTC(0.00029);
+            const amount = new BitcoinAmount(0.00029);
 
             const txData = await bitcoinCoreClient.broadcastTx(recipientAddress, amount, opReturnValue);
             // transaction in mempool

--- a/test/integration/parachain/release/redeem.test.ts
+++ b/test/integration/parachain/release/redeem.test.ts
@@ -1,9 +1,7 @@
 import { ApiPromise, Keyring } from "@polkadot/api";
 import { KeyringPair } from "@polkadot/keyring/types";
 import { Hash } from "@polkadot/types/interfaces";
-import { Currency } from "@interlay/monetary-js";
 import {
-    CollateralUnit,
     currencyIdToMonetaryCurrency,
     DefaultInterBtcApi,
     InterBtcApi,
@@ -110,13 +108,10 @@ describe("redeem", () => {
             const collateralCurrency = currencyIdToMonetaryCurrency(
                 vaultToLiquidateId.currencies.collateral
             ) as CollateralCurrency;
-            const regularExchangeRate = await oracleInterBtcAPI.oracle.getExchangeRate(
-                collateralCurrency as Currency<CollateralUnit>
-            );
+            const regularExchangeRate = await oracleInterBtcAPI.oracle.getExchangeRate(collateralCurrency);
 
             // There should be no burnable tokens
-            await expect(userInterBtcAPI.redeem.getBurnExchangeRate(collateralCurrency as Currency<CollateralUnit>)).to
-                .be.rejected;
+            await expect(userInterBtcAPI.redeem.getBurnExchangeRate(collateralCurrency)).to.be.rejected;
 
             // issue a small amount of tokens (10x dust)
             const dustValue = await userInterBtcAPI.issue.getDustValue();
@@ -178,9 +173,7 @@ describe("redeem", () => {
                 (issued tokens: ${issuedTokens.toHuman()}; collateral: ${collateralCurrency.ticker}) 
                 but was ${maxBurnableTokens.toHuman()}`
             );
-            const burnExchangeRate = await userInterBtcAPI.redeem.getBurnExchangeRate(
-                collateralCurrency as Currency<CollateralUnit>
-            );
+            const burnExchangeRate = await userInterBtcAPI.redeem.getBurnExchangeRate(collateralCurrency);
             assert.isTrue(
                 regularExchangeRate.toBig().lt(burnExchangeRate.toBig()),
                 `Burn exchange rate (${burnExchangeRate.toHuman()}) is not better than 

--- a/test/integration/parachain/staging/fee.test.ts
+++ b/test/integration/parachain/staging/fee.test.ts
@@ -1,17 +1,17 @@
 import { ApiPromise, Keyring } from "@polkadot/api";
-import { Bitcoin, BitcoinUnit, Currency, ExchangeRate } from "@interlay/monetary-js";
+import { Bitcoin, ExchangeRate } from "@interlay/monetary-js";
 import { assert } from "chai";
 import Big from "big.js";
 
 import { createSubstrateAPI } from "../../../../src/factory";
 import { ESPLORA_BASE_PATH, ORACLE_URI, PARACHAIN_ENDPOINT } from "../../../config";
-import { 
-    CollateralUnit, 
-    DefaultInterBtcApi, 
-    getCorrespondingCollateralCurrencies, 
-    InterBtcApi, 
-    newMonetaryAmount, 
-    WrappedCurrency 
+import {
+    CollateralCurrency,
+    DefaultInterBtcApi,
+    getCorrespondingCollateralCurrencies,
+    InterBtcApi,
+    newMonetaryAmount,
+    WrappedCurrency,
 } from "../../../../src";
 import { GriefingCollateralType } from "../../../../src/parachain/fee";
 import { callWithExchangeRate } from "../../../utils/helpers";
@@ -19,7 +19,7 @@ import { callWithExchangeRate } from "../../../utils/helpers";
 describe("fee", () => {
     let api: ApiPromise;
     let oracleInterBtcAPI: InterBtcApi;
-    let collateralCurrencies: Array<Currency<CollateralUnit>>;
+    let collateralCurrencies: Array<CollateralCurrency>;
     let wrappedCurrency: WrappedCurrency;
 
     before(async function () {
@@ -27,8 +27,7 @@ describe("fee", () => {
         const keyring = new Keyring({ type: "sr25519" });
         const oracleAccount = keyring.addFromUri(ORACLE_URI);
         oracleInterBtcAPI = new DefaultInterBtcApi(api, "regtest", oracleAccount, ESPLORA_BASE_PATH);
-        collateralCurrencies = 
-            getCorrespondingCollateralCurrencies(oracleInterBtcAPI.getGovernanceCurrency()) as Array<Currency<CollateralUnit>>;
+        collateralCurrencies = getCorrespondingCollateralCurrencies(oracleInterBtcAPI.getGovernanceCurrency());
         wrappedCurrency = oracleInterBtcAPI.getWrappedCurrency();
     });
 
@@ -45,16 +44,18 @@ describe("fee", () => {
     it.skip("should getGriefingCollateral for issue", async () => {
         for (const collateralCurrency of collateralCurrencies) {
             const exchangeRateValue = new Big("3855.23187");
-            const exchangeRate = new ExchangeRate<
+            const exchangeRate = new ExchangeRate<Bitcoin, typeof collateralCurrency>(
                 Bitcoin,
-                BitcoinUnit,
-                typeof collateralCurrency,
-                typeof collateralCurrency.units
-            >(Bitcoin, collateralCurrency, exchangeRateValue);
+                collateralCurrency,
+                exchangeRateValue
+            );
             await callWithExchangeRate(oracleInterBtcAPI.oracle, exchangeRate, async () => {
                 const amountBtc = newMonetaryAmount(0.001, wrappedCurrency, true);
-                const griefingCollateral = await oracleInterBtcAPI.fee.getGriefingCollateral(amountBtc, GriefingCollateralType.Issue);
-                assert.equal(griefingCollateral.toBig(griefingCollateral.currency.base).round(5, 0).toString(), "0.00001");
+                const griefingCollateral = await oracleInterBtcAPI.fee.getGriefingCollateral(
+                    amountBtc,
+                    GriefingCollateralType.Issue
+                );
+                assert.equal(griefingCollateral.toBig().round(5, 0).toString(), "0.00001");
             });
         }
     }).timeout(2 * 200000);
@@ -63,17 +64,18 @@ describe("fee", () => {
     it.skip("should getGriefingCollateral for replace", async () => {
         for (const collateralCurrency of collateralCurrencies) {
             const exchangeRateValue = new Big("3855.23187");
-            const exchangeRate = new ExchangeRate<
+            const exchangeRate = new ExchangeRate<Bitcoin, typeof collateralCurrency>(
                 Bitcoin,
-                BitcoinUnit,
-                typeof collateralCurrency,
-                typeof collateralCurrency.units
-                >(Bitcoin, collateralCurrency, exchangeRateValue);
+                collateralCurrency,
+                exchangeRateValue
+            );
             await callWithExchangeRate(oracleInterBtcAPI.oracle, exchangeRate, async () => {
                 const amountToReplace = newMonetaryAmount(0.728, wrappedCurrency, true);
-                const griefingCollateral = 
-                    await oracleInterBtcAPI.fee.getGriefingCollateral(amountToReplace, GriefingCollateralType.Replace);
-                assert.equal(griefingCollateral.toString(griefingCollateral.currency.base), "16.744");
+                const griefingCollateral = await oracleInterBtcAPI.fee.getGriefingCollateral(
+                    amountToReplace,
+                    GriefingCollateralType.Replace
+                );
+                assert.equal(griefingCollateral.toString(), "16.744");
             });
         }
     }).timeout(2 * 200000);

--- a/test/integration/parachain/staging/sequential/escrow.test.ts
+++ b/test/integration/parachain/staging/sequential/escrow.test.ts
@@ -1,6 +1,5 @@
 import { ApiPromise, Keyring } from "@polkadot/api";
 import { assert } from "chai";
-import { Currency } from "@interlay/monetary-js";
 import { KeyringPair } from "@polkadot/keyring/types";
 import BN from "bn.js";
 import Big, { RoundingMode } from "big.js";
@@ -16,7 +15,7 @@ import {
 } from "../../../../config";
 import {
     DefaultInterBtcApi,
-    GovernanceUnit,
+    GovernanceCurrency,
     newAccountId,
     newMonetaryAmount,
     setNumericStorage,
@@ -32,7 +31,7 @@ describe("escrow", () => {
     let userAccount_3: KeyringPair;
     let sudoAccount: KeyringPair;
 
-    let governanceCurrency: Currency<GovernanceUnit>;
+    let governanceCurrency: GovernanceCurrency;
 
     before(async function () {
         const keyring = new Keyring({ type: "sr25519" });
@@ -111,16 +110,10 @@ describe("escrow", () => {
             currentBlockNumber + 0.4 * unlockHeightDiff
         );
         const votingSupply = await interBtcAPI.escrow.totalVotingSupply(currentBlockNumber + 0.4 * unlockHeightDiff);
-        assert.equal(
-            votingBalance.toString(votingBalance.currency.base),
-            votingSupply.toString(votingSupply.currency.base)
-        );
+        assert.equal(votingBalance.toString(), votingSupply.toString());
 
         // Hardcoded value here to match the parachain
-        assert.equal(
-            votingSupply.toBig(votingSupply.currency.base).round(2, RoundingMode.RoundDown).toString(),
-            "0.62"
-        );
+        assert.equal(votingSupply.toBig().round(2, RoundingMode.RoundDown).toString(), "0.62");
         const firstYearRewards = 125000000000000000;
         const blocksPerYear = 5256000;
 
@@ -155,13 +148,7 @@ describe("escrow", () => {
         const votingSupplyAfterSecondUser = await interBtcAPI.escrow.totalVotingSupply(
             currentBlockNumber + 0.4 * unlockHeightDiff
         );
-        assert.equal(
-            votingSupplyAfterSecondUser
-                .toBig(votingSupplyAfterSecondUser.currency.base)
-                .round(2, RoundingMode.RoundDown)
-                .toString(),
-            "0.99"
-        );
+        assert.equal(votingSupplyAfterSecondUser.toBig().round(2, RoundingMode.RoundDown).toString(), "0.99");
 
         const stakedTotalAfter = await interBtcAPI.escrow.getTotalStakedBalance();
         const lockedBalanceTotal = user1_intrAmount.add(user2_intrAmount);

--- a/test/integration/parachain/staging/sequential/oracle.test.ts
+++ b/test/integration/parachain/staging/sequential/oracle.test.ts
@@ -1,17 +1,22 @@
 import { ApiPromise, Keyring } from "@polkadot/api";
 import { KeyringPair } from "@polkadot/keyring/types";
-import { Bitcoin, BitcoinAmount, BitcoinUnit, Currency, ExchangeRate } from "@interlay/monetary-js";
+import { Bitcoin, BitcoinAmount, ExchangeRate } from "@interlay/monetary-js";
 
 import { createSubstrateAPI } from "../../../../../src/factory";
 import { assert } from "../../../../chai";
 import { ESPLORA_BASE_PATH, ORACLE_URI, PARACHAIN_ENDPOINT } from "../../../../config";
-import { CollateralUnit, DefaultInterBtcApi, getCorrespondingCollateralCurrencies, InterBtcApi } from "../../../../../src";
+import {
+    CollateralCurrency,
+    DefaultInterBtcApi,
+    getCorrespondingCollateralCurrencies,
+    InterBtcApi,
+} from "../../../../../src";
 import { getExchangeRateValueToSetForTesting } from "../../../../utils/helpers";
 
 describe("OracleAPI", () => {
     let api: ApiPromise;
     let interBtcAPI: InterBtcApi;
-    let collateralCurrencies: Array<Currency<CollateralUnit>>;
+    let collateralCurrencies: Array<CollateralCurrency>;
     let oracleAccount: KeyringPair;
 
     before(async () => {
@@ -19,7 +24,7 @@ describe("OracleAPI", () => {
         const keyring = new Keyring({ type: "sr25519" });
         oracleAccount = keyring.addFromUri(ORACLE_URI);
         interBtcAPI = new DefaultInterBtcApi(api, "regtest", oracleAccount, ESPLORA_BASE_PATH);
-        collateralCurrencies = getCorrespondingCollateralCurrencies(interBtcAPI.getGovernanceCurrency()) as Array<Currency<CollateralUnit>>;
+        collateralCurrencies = getCorrespondingCollateralCurrencies(interBtcAPI.getGovernanceCurrency());
     });
 
     after(() => {
@@ -29,26 +34,28 @@ describe("OracleAPI", () => {
     it("should set exchange rate", async () => {
         for (const collateralCurrency of collateralCurrencies) {
             const exchangeRateValue = getExchangeRateValueToSetForTesting(collateralCurrency);
-            const newExchangeRate = new ExchangeRate<
+            const newExchangeRate = new ExchangeRate<Bitcoin, typeof collateralCurrency>(
                 Bitcoin,
-                BitcoinUnit,
-                typeof collateralCurrency,
-                typeof collateralCurrency.units
-            >(Bitcoin, collateralCurrency, exchangeRateValue);
+                collateralCurrency,
+                exchangeRateValue
+            );
             await interBtcAPI.oracle.setExchangeRate(newExchangeRate);
             await interBtcAPI.oracle.waitForExchangeRateUpdate(newExchangeRate);
         }
     });
 
     it("should convert satoshi to collateral currency", async () => {
-        for(const collateralCurrency of collateralCurrencies) {
-            const bitcoinAmount = BitcoinAmount.from.BTC(100);
+        for (const collateralCurrency of collateralCurrencies) {
+            const bitcoinAmount = new BitcoinAmount(100);
             const exchangeRate = await interBtcAPI.oracle.getExchangeRate(collateralCurrency);
-            const expectedCollateral = exchangeRate.toBig(undefined).mul(bitcoinAmount.toBig(BitcoinUnit.BTC)).round(0, 0);
-    
-            const collateralAmount = await interBtcAPI.oracle.convertWrappedToCurrency(bitcoinAmount, collateralCurrency);
+            const expectedCollateral = exchangeRate.toBig().mul(bitcoinAmount.toBig(Bitcoin.decimals)).round(0, 0);
+
+            const collateralAmount = await interBtcAPI.oracle.convertWrappedToCurrency(
+                bitcoinAmount,
+                collateralCurrency
+            );
             assert.equal(
-                collateralAmount.toBig(collateralCurrency.base).round(0, 0).toString(), 
+                collateralAmount.toBig(collateralCurrency.decimals).round(0, 0).toString(),
                 expectedCollateral.toString(),
                 `Unexpected collateral (${collateralCurrency.ticker}) amount`
             );
@@ -73,11 +80,14 @@ describe("OracleAPI", () => {
     });
 
     it("should getValidUntil", async () => {
-        for(const collateralCurrency of collateralCurrencies) {
+        for (const collateralCurrency of collateralCurrencies) {
             const validUntil = await interBtcAPI.oracle.getValidUntil(collateralCurrency);
             const dateAnHourFromNow = new Date();
             dateAnHourFromNow.setMinutes(dateAnHourFromNow.getMinutes() + 30);
-            assert.isTrue(validUntil > dateAnHourFromNow, `lastExchangeRateTime is older than one hour (${collateralCurrency.ticker})`);
+            assert.isTrue(
+                validUntil > dateAnHourFromNow,
+                `lastExchangeRateTime is older than one hour (${collateralCurrency.ticker})`
+            );
         }
     });
 

--- a/test/integration/parachain/staging/sequential/redeem.test.ts
+++ b/test/integration/parachain/staging/sequential/redeem.test.ts
@@ -6,7 +6,7 @@ import {
     DefaultInterBtcApi,
     InterBtcApi,
     InterbtcPrimitivesVaultId,
-    VaultRegistryVault
+    VaultRegistryVault,
 } from "../../../../../src/index";
 import { createSubstrateAPI } from "../../../../../src/factory";
 import { assert, expect } from "../../../../chai";
@@ -23,7 +23,12 @@ import {
     VAULT_2_URI,
     ESPLORA_BASE_PATH,
 } from "../../../../config";
-import { getCorrespondingCollateralCurrencies, issueAndRedeem, newMonetaryAmount, stripHexPrefix } from "../../../../../src/utils";
+import {
+    getCorrespondingCollateralCurrencies,
+    issueAndRedeem,
+    newMonetaryAmount,
+    stripHexPrefix,
+} from "../../../../../src/utils";
 import { BitcoinCoreClient } from "../../../../../src/utils/bitcoin-core-client";
 import { newVaultId, WrappedCurrency } from "../../../../../src";
 import { ExecuteRedeem } from "../../../../../src/utils/issueRedeem";
@@ -64,7 +69,7 @@ describe("redeem", () => {
         vault_1 = keyring.addFromUri(VAULT_1_URI);
         vault_2 = keyring.addFromUri(VAULT_2_URI);
 
-        collateralCurrencies.forEach(collateralCurrency => {
+        collateralCurrencies.forEach((collateralCurrency) => {
             const vault_1_id = newVaultId(api, vault_1.address, collateralCurrency, wrappedCurrency);
             const vault_2_id = newVaultId(api, vault_2.address, collateralCurrency, wrappedCurrency);
             collateralTickerToVaultIdsMap.set(collateralCurrency.ticker, [vault_1_id, vault_2_id]);
@@ -104,7 +109,7 @@ describe("redeem", () => {
                 false,
                 ExecuteRedeem.False
             );
-            
+
             await issueAndRedeem(
                 interBtcAPI,
                 bitcoinCoreClient,
@@ -143,25 +148,26 @@ describe("redeem", () => {
             const actualTxFeeSatoshi = new Big(btcTx.fee || 0);
             const actualTxVsize = calculateBtcTxVsize(btcTx);
             if (actualTxVsize.eq(0)) {
-                assert.fail(`Invalid actual tx vsize of 0, cannot calculate fee rate for redeem request id ${redeemRequest.id}`);
+                assert.fail(
+                    `Invalid actual tx vsize of 0, cannot calculate fee rate for redeem request id ${redeemRequest.id}`
+                );
                 return;
             }
-            
-            // allowable delta from observations: now and then, the fee is off by 1 satoshi, 
+
+            // allowable delta from observations: now and then, the fee is off by 1 satoshi,
             // so allow for that difference plus some epsilon (1e-5)
             const expectedFees = oracleBtcFeePerByte.mul(actualTxVsize);
             const allowedFeesMax = expectedFees.plus(1);
             const allowedFeeDelta = allowedFeesMax.div(expectedFees).plus(0.00001);
-            
+
             const actualFeeRateSatoshiPerByte = actualTxFeeSatoshi.div(actualTxVsize);
-            expect(actualFeeRateSatoshiPerByte.toNumber())
-                .to.be.closeTo(
-                    allowedFeeDelta.toNumber(),
-                    oracleBtcFeePerByte.toNumber(),
-                    `BTC fee rate for redeem request id ${redeemRequest.id} is not close to expected value.
+            expect(actualFeeRateSatoshiPerByte.toNumber()).to.be.closeTo(
+                allowedFeeDelta.toNumber(),
+                oracleBtcFeePerByte.toNumber(),
+                `BTC fee rate for redeem request id ${redeemRequest.id} is not close to expected value.
                     Maximum allowed delta is ${allowedFeeDelta.toNumber()}.
                     BTC tx rate is ${actualFeeRateSatoshiPerByte.toString()}, but oracle rate is ${oracleBtcFeePerByte.toString()}`
-                );
+            );
         }
     }).timeout(10 * 60000);
 
@@ -169,7 +175,10 @@ describe("redeem", () => {
     // And while we have the data, we might as well check if the new fee is indeed elevated.
     it("should be able to perform RBF on a redeem transaction", async () => {
         // grab only first entry (collateral currency), and only vault_1_id
-        const [vault_1_id] = collateralTickerToVaultIdsMap.values().next().value as [InterbtcPrimitivesVaultId, InterbtcPrimitivesVaultId];
+        const [vault_1_id] = collateralTickerToVaultIdsMap.values().next().value as [
+            InterbtcPrimitivesVaultId,
+            InterbtcPrimitivesVaultId
+        ];
         const issueAmount = newMonetaryAmount(0.0001, wrappedCurrency, true);
         const redeemAmount = newMonetaryAmount(0.00007, wrappedCurrency, true);
 
@@ -209,7 +218,11 @@ describe("redeem", () => {
         const feesBefore = result.origfee;
         const feesAfter = result.fee;
 
-        assert.isAbove(feesAfter, feesBefore, `Fees did not increase after bumpfee for redeem request id ${redeemRequest.id}`);
+        assert.isAbove(
+            feesAfter,
+            feesBefore,
+            `Fees did not increase after bumpfee for redeem request id ${redeemRequest.id}`
+        );
     }).timeout(10 * 60000);
 
     // TODO: maybe add this to redeem API
@@ -221,7 +234,7 @@ describe("redeem", () => {
     it("should getFeesToPay", async () => {
         const amount = newMonetaryAmount(2, wrappedCurrency, true);
         const feesToPay = await interBtcAPI.redeem.getFeesToPay(amount);
-        assert.equal(feesToPay.str.BTC(), "0.01");
+        assert.equal(feesToPay.toString(), "0.01");
     });
 
     it("should getFeeRate", async () => {
@@ -241,7 +254,6 @@ describe("redeem", () => {
 
     it("should getDustValue", async () => {
         const dustValue = await interBtcAPI.redeem.getDustValue();
-        assert.equal(dustValue.str.BTC(), "0.00001");
+        assert.equal(dustValue.toString(), "0.00001");
     });
-
 });

--- a/test/integration/parachain/staging/sequential/replace.test.ts
+++ b/test/integration/parachain/staging/sequential/replace.test.ts
@@ -1,12 +1,12 @@
 import { ApiPromise, Keyring } from "@polkadot/api";
 import { KeyringPair } from "@polkadot/keyring/types";
-import { 
+import {
     currencyIdToLiteral,
-    DefaultInterBtcApi, 
-    DefaultTransactionAPI, 
-    getCorrespondingCollateralCurrencies, 
-    InterBtcApi, 
-    InterbtcPrimitivesVaultId, 
+    DefaultInterBtcApi,
+    DefaultTransactionAPI,
+    getCorrespondingCollateralCurrencies,
+    InterBtcApi,
+    InterbtcPrimitivesVaultId,
     newMonetaryAmount,
 } from "../../../../../src/index";
 
@@ -27,8 +27,14 @@ import {
 } from "../../../../config";
 import { assert, expect } from "../../../../chai";
 import { issueSingle } from "../../../../../src/utils/issueRedeem";
-import { CollateralCurrency, currencyIdToMonetaryCurrency, newAccountId, newVaultId, WrappedCurrency } from "../../../../../src";
-import { BitcoinUnit, MonetaryAmount } from "@interlay/monetary-js";
+import {
+    CollateralCurrency,
+    currencyIdToMonetaryCurrency,
+    newAccountId,
+    newVaultId,
+    WrappedCurrency,
+} from "../../../../../src";
+import { MonetaryAmount } from "@interlay/monetary-js";
 
 describe("replace", () => {
     let api: ApiPromise;
@@ -60,11 +66,13 @@ describe("replace", () => {
         wrappedCurrency = interBtcAPI.getWrappedCurrency();
         const collateralCurrencies = getCorrespondingCollateralCurrencies(interBtcAPI.getGovernanceCurrency());
         vault_3 = keyring.addFromUri(VAULT_3_URI);
-        vault_3_ids = collateralCurrencies
-            .map(collateralCurrency => newVaultId(api, vault_3.address, collateralCurrency, wrappedCurrency));
+        vault_3_ids = collateralCurrencies.map((collateralCurrency) =>
+            newVaultId(api, vault_3.address, collateralCurrency, wrappedCurrency)
+        );
         vault_2 = keyring.addFromUri(VAULT_2_URI);
-        vault_2_ids = collateralCurrencies
-            .map(collateralCurrency => newVaultId(api, vault_2.address, collateralCurrency, wrappedCurrency));
+        vault_2_ids = collateralCurrencies.map((collateralCurrency) =>
+            newVaultId(api, vault_2.address, collateralCurrency, wrappedCurrency)
+        );
     });
 
     after(async () => {
@@ -72,12 +80,12 @@ describe("replace", () => {
     });
 
     describe("request", () => {
-        let dustValue: MonetaryAmount<WrappedCurrency, BitcoinUnit>;
-        let feesEstimate: MonetaryAmount<WrappedCurrency, BitcoinUnit>;
+        let dustValue: MonetaryAmount<WrappedCurrency>;
+        let feesEstimate: MonetaryAmount<WrappedCurrency>;
 
         before(async () => {
             dustValue = await interBtcAPI.replace.getDustValue();
-            feesEstimate = newMonetaryAmount((await interBtcAPI.oracle.getBitcoinFees()), wrappedCurrency, false);
+            feesEstimate = newMonetaryAmount(await interBtcAPI.oracle.getBitcoinFees(), wrappedCurrency, false);
         });
 
         it("should request vault replacement", async () => {
@@ -85,56 +93,50 @@ describe("replace", () => {
                 // try to set value above dust + estimated fees
                 const issueAmount = dustValue.add(feesEstimate).mul(1.2);
                 const replaceAmount = dustValue;
-                await issueSingle(
-                    interBtcAPI,
-                    bitcoinCoreClient,
-                    userAccount,
-                    issueAmount,
-                    vault_3_id
-                );
-    
+                await issueSingle(interBtcAPI, bitcoinCoreClient, userAccount, issueAmount, vault_3_id);
+
                 interBtcAPI.setAccount(vault_3);
                 await interBtcAPI.replace.request(
-                    replaceAmount, 
+                    replaceAmount,
                     currencyIdToMonetaryCurrency(vault_3_id.currencies.collateral) as CollateralCurrency
                 );
-    
-                const finalizedPromise = new Promise<void>((resolve, _) => interBtcAPI.system.subscribeToFinalizedBlockHeads(
-                    async (header) => {
+
+                const finalizedPromise = new Promise<void>((resolve, _) =>
+                    interBtcAPI.system.subscribeToFinalizedBlockHeads(async (header) => {
                         const events = await interBtcAPI.api.query.system.events.at(header.parentHash);
                         if (DefaultTransactionAPI.doesArrayContainEvent(events, api.events.replace.AcceptReplace)) {
                             resolve();
                         }
                     })
                 );
-    
+
                 await finalizedPromise;
             }
 
             const requestsList = await interBtcAPI.replace.list();
             const requestsMap = await interBtcAPI.replace.map();
             assert.equal(
-                requestsList.length, 
-                vault_3_ids.length, 
+                requestsList.length,
+                vault_3_ids.length,
                 `Expected ${vault_3_ids.length} requests in list, got ${requestsList.length}`
             );
             assert.equal(
-                requestsMap.size, 
+                requestsMap.size,
                 vault_3_ids.length,
                 `Expected ${vault_3_ids.length} requests in map, got ${requestsMap.size}`
             );
 
             // Need to manually compare some fields
-            const membersFromListToExpect = requestsList.map(req => ({
+            const membersFromListToExpect = requestsList.map((req) => ({
                 btcAddress: req.btcAddress,
                 btcHeight: req.btcHeight,
-                amount: req.amount.toString()
+                amount: req.amount.toString(),
             }));
 
-            const membersFromMapToCheck = Array.from(requestsMap.values()).map(req => ({
+            const membersFromMapToCheck = Array.from(requestsMap.values()).map((req) => ({
                 btcAddress: req.btcAddress,
                 btcHeight: req.btcHeight,
-                amount: req.amount.toString()
+                amount: req.amount.toString(),
             }));
 
             expect(membersFromMapToCheck).to.deep.include.members(membersFromListToExpect);
@@ -144,25 +146,28 @@ describe("replace", () => {
             for (const vault_2_id of vault_2_ids) {
                 const currencyTicker = currencyIdToMonetaryCurrency(vault_2_id.currencies.collateral).ticker;
                 interBtcAPI.setAccount(vault_2);
-    
+
                 // fetch tokens held by vault
                 const tokensInVault = await interBtcAPI.vaults.getIssuedAmount(
                     newAccountId(api, vault_2.address),
                     currencyIdToLiteral(vault_2_id.currencies.collateral)
                 );
-    
+
                 // make sure vault does not hold enough issued tokens to request a replace
                 const replaceAmount = dustValue.add(tokensInVault);
-                
+
                 try {
                     await interBtcAPI.replace.request(
-                        replaceAmount, 
+                        replaceAmount,
                         currencyIdToMonetaryCurrency(vault_2_id.currencies.collateral) as CollateralCurrency
                     );
                     assert.fail(`Expected error to be thrown due to lack of issued tokens
                         for vault (collateral: ${currencyTicker}), but call completed.`);
                 } catch (e) {
-                    assert.isTrue(e instanceof Error, `Expected replace request to fail with Error (${currencyTicker} vault)`);
+                    assert.isTrue(
+                        e instanceof Error,
+                        `Expected replace request to fail with Error (${currencyTicker} vault)`
+                    );
                 }
             }
         }).timeout(600000);
@@ -170,7 +175,7 @@ describe("replace", () => {
 
     it("should getDustValue", async () => {
         const dustValue = await interBtcAPI.replace.getDustValue();
-        assert.equal(dustValue.str.BTC(), "0.00001");
+        assert.equal(dustValue.toString(), "0.00001");
     }).timeout(500);
 
     it("should getReplacePeriod", async () => {
@@ -185,5 +190,4 @@ describe("replace", () => {
             assert.deepEqual(request.oldVault.accountId, vault3Id);
         });
     });
-
 });

--- a/test/integration/parachain/staging/setup/initialize.test.ts
+++ b/test/integration/parachain/staging/setup/initialize.test.ts
@@ -1,7 +1,7 @@
 import { ApiPromise, Keyring } from "@polkadot/api";
 import { KeyringPair } from "@polkadot/keyring/types";
 import { AccountId } from "@polkadot/types/interfaces";
-import { Bitcoin, BitcoinUnit, Currency, ExchangeRate, Kintsugi, Kusama, Polkadot } from "@interlay/monetary-js";
+import { Bitcoin, Currency, ExchangeRate, Kintsugi, Kusama, Polkadot } from "@interlay/monetary-js";
 import { assert } from "chai";
 import Big from "big.js";
 
@@ -10,7 +10,6 @@ import {
     createSubstrateAPI,
     VaultsAPI,
     newAccountId,
-    CollateralUnit,
     CurrencyIdLiteral,
     InterBtcApi,
     DefaultInterBtcApi,
@@ -161,12 +160,8 @@ describe("Initialize parachain state", () => {
     });
 
     it("should set the exchange rate", async () => {
-        async function setCollateralExchangeRate<C extends CollateralUnit>(value: Big, currency: Currency<C>) {
-            const exchangeRate = new ExchangeRate<Bitcoin, BitcoinUnit, typeof currency, typeof currency.units>(
-                Bitcoin,
-                currency,
-                value
-            );
+        async function setCollateralExchangeRate(value: Big, currency: Currency) {
+            const exchangeRate = new ExchangeRate<Bitcoin, typeof currency>(Bitcoin, currency, value);
             // result will be medianized
             await initializeExchangeRate(exchangeRate, sudoInterBtcAPI.oracle);
         }

--- a/test/integration/parachain/staging/tokens.test.ts
+++ b/test/integration/parachain/staging/tokens.test.ts
@@ -6,9 +6,9 @@ import { createSubstrateAPI } from "../../../../src/factory";
 import { assert } from "../../../chai";
 import { USER_1_URI, USER_2_URI, PARACHAIN_ENDPOINT, ESPLORA_BASE_PATH } from "../../../config";
 import {
+    ATOMIC_UNIT,
     ChainBalance,
-    CollateralUnit,
-    CurrencyUnit,
+    CollateralCurrency,
     DefaultInterBtcApi,
     getCorrespondingCollateralCurrencies,
     InterBtcApi,
@@ -21,7 +21,7 @@ describe("TokensAPI", () => {
     let user1Account: KeyringPair;
     let user2Account: KeyringPair;
     let interBtcAPI: InterBtcApi;
-    let collateralCurrencies: Array<Currency<CollateralUnit>>;
+    let collateralCurrencies: Array<CollateralCurrency>;
 
     before(async () => {
         api = await createSubstrateAPI(PARACHAIN_ENDPOINT);
@@ -29,8 +29,7 @@ describe("TokensAPI", () => {
         user1Account = keyring.addFromUri(USER_1_URI);
         user2Account = keyring.addFromUri(USER_2_URI);
         interBtcAPI = new DefaultInterBtcApi(api, "regtest", user1Account, ESPLORA_BASE_PATH);
-        collateralCurrencies = 
-            getCorrespondingCollateralCurrencies(interBtcAPI.getGovernanceCurrency()) as Array<Currency<CollateralUnit>>;
+        collateralCurrencies = getCorrespondingCollateralCurrencies(interBtcAPI.getGovernanceCurrency());
     });
 
     after(() => {
@@ -43,16 +42,16 @@ describe("TokensAPI", () => {
         }
     });
 
-    async function testBalanceSubscription<U extends CurrencyUnit>(currency: Currency<U>): Promise<void> {
+    async function testBalanceSubscription(currency: Currency): Promise<void> {
         // Subscribe and receive two balance updates
-        let updatedBalance = new ChainBalance<U>(currency);
+        let updatedBalance = new ChainBalance(currency);
         let updatedAccount = "";
-        function balanceUpdateCallback(account: string, newBalance: ChainBalance<U>) {
+        function balanceUpdateCallback(account: string, newBalance: ChainBalance) {
             updatedBalance = newBalance;
             updatedAccount = account;
         }
         const amountToUpdateUser2sAccountBy = newMonetaryAmount(10, currency, true);
-        const user2BalanceBeforeTransfer = await interBtcAPI.tokens.balance<typeof currency.units>(
+        const user2BalanceBeforeTransfer = await interBtcAPI.tokens.balance(
             currency,
             newAccountId(api, user2Account.address)
         );
@@ -65,22 +64,22 @@ describe("TokensAPI", () => {
         // Send the first transfer, expect the callback to be called with correct values
         await interBtcAPI.tokens.transfer(user2Account.address, amountToUpdateUser2sAccountBy);
         assert.equal(updatedAccount, user2Account.address);
-        const expectedUser2BalanceAfterFirstTransfer = new ChainBalance<U>(
+        const expectedUser2BalanceAfterFirstTransfer = new ChainBalance(
             currency,
-            user2BalanceBeforeTransfer.free.add(amountToUpdateUser2sAccountBy).toBig(),
-            user2BalanceBeforeTransfer.transferable.add(amountToUpdateUser2sAccountBy).toBig(),
-            user2BalanceBeforeTransfer.reserved.toBig()
+            user2BalanceBeforeTransfer.free.add(amountToUpdateUser2sAccountBy).toBig(ATOMIC_UNIT),
+            user2BalanceBeforeTransfer.transferable.add(amountToUpdateUser2sAccountBy).toBig(ATOMIC_UNIT),
+            user2BalanceBeforeTransfer.reserved.toBig(ATOMIC_UNIT)
         );
         assert.equal(updatedBalance.toString(), expectedUser2BalanceAfterFirstTransfer.toString());
 
         // Send the second transfer, expect the callback to be called with correct values
         await interBtcAPI.tokens.transfer(user2Account.address, amountToUpdateUser2sAccountBy);
         assert.equal(updatedAccount, user2Account.address);
-        const expectedUser2BalanceAfterSecondTransfer = new ChainBalance<U>(
+        const expectedUser2BalanceAfterSecondTransfer = new ChainBalance(
             currency,
-            expectedUser2BalanceAfterFirstTransfer.free.add(amountToUpdateUser2sAccountBy).toBig(),
-            expectedUser2BalanceAfterFirstTransfer.transferable.add(amountToUpdateUser2sAccountBy).toBig(),
-            expectedUser2BalanceAfterFirstTransfer.reserved.toBig()
+            expectedUser2BalanceAfterFirstTransfer.free.add(amountToUpdateUser2sAccountBy).toBig(ATOMIC_UNIT),
+            expectedUser2BalanceAfterFirstTransfer.transferable.add(amountToUpdateUser2sAccountBy).toBig(ATOMIC_UNIT),
+            expectedUser2BalanceAfterFirstTransfer.reserved.toBig(ATOMIC_UNIT)
         );
         assert.equal(updatedBalance.toString(), expectedUser2BalanceAfterSecondTransfer.toString());
 

--- a/test/unit/mocks/vaultsTestMocks.ts
+++ b/test/unit/mocks/vaultsTestMocks.ts
@@ -2,7 +2,6 @@ import Big, { BigSource } from "big.js";
 import sinon from "sinon";
 import {
     CollateralCurrency,
-    CurrencyUnit,
     DefaultRewardsAPI,
     DefaultVaultsAPI,
     InterbtcPrimitivesVaultId,
@@ -12,7 +11,7 @@ import {
 import * as allThingsCurrency from "../../../src/types/currency";
 import * as allThingsEncoding from "../../../src/utils/encoding";
 import { AccountId } from "@polkadot/types/interfaces";
-import { BitcoinUnit, Currency } from "@interlay/monetary-js";
+import { Currency } from "@interlay/monetary-js";
 
 export type NominatorVaultAccountIds = {
     nominatorId: AccountId;
@@ -47,7 +46,7 @@ export const prepareBackingCollateralProportionMocks = (
         sinon,
         stubbedRewardsApi,
         nominatorCollateralStakedAmount,
-        collateralCurrency as any
+        collateralCurrency
     );
     mockCurrencyIdLiteralToMonetaryCurrency(sinon, collateralCurrency);
 
@@ -78,11 +77,11 @@ export const createMockAccountId = (someString: string): AccountId => {
  * @param amount The mocked return amount
  * @param currency The currency of the mocked return amount
  */
-export const mockComputeCollateralInStakingPoolMethod = <U extends CurrencyUnit>(
+export const mockComputeCollateralInStakingPoolMethod = (
     sinon: sinon.SinonSandbox,
     stubbedRewardsApi: sinon.SinonStubbedInstance<DefaultRewardsAPI>,
     amount: BigSource,
-    currency: Currency<U>
+    currency: Currency
 ): void => {
     // don't care what the inner method returns as we mock the outer one
     const tempId = <InterbtcPrimitivesVaultId>{};
@@ -98,10 +97,7 @@ export const mockComputeCollateralInStakingPoolMethod = <U extends CurrencyUnit>
  * @param collateralCurrency The collateral currency for the mocked backing collateral amount
  * @returns A mocked VaultExt instance with only backingCollateral property set
  */
-export const createMockVaultWithBacking = (
-    amount: BigSource,
-    collateralCurrency: CollateralCurrency
-): VaultExt<BitcoinUnit> => {
+export const createMockVaultWithBacking = (amount: BigSource, collateralCurrency: CollateralCurrency): VaultExt => {
     // VaultExt-ish; only need .backingCollateral to be available for this test
     return {
         backingCollateral: newMonetaryAmount(amount, collateralCurrency as any),
@@ -117,7 +113,7 @@ export const createMockVaultWithBacking = (
 export const mockVaultsApiGetMethod = (
     sinon: sinon.SinonSandbox,
     vaultsApi: DefaultVaultsAPI,
-    vault: VaultExt<BitcoinUnit>
+    vault: VaultExt
 ): void => {
     // make VaultAPI.get() return a mocked vault
     sinon.stub(vaultsApi, "get").returns(Promise.resolve(vault));

--- a/test/unit/parachain/asset-registry.test.ts
+++ b/test/unit/parachain/asset-registry.test.ts
@@ -10,12 +10,12 @@ describe("DefaultAssetRegistryAPI", () => {
     let api: ApiPromise;
     let assetRegistryApi: DefaultAssetRegistryAPI;
     let mockMetadata: OrmlAssetRegistryAssetMetadata;
-    const mockMetadataValues =  {
+    const mockMetadataValues = {
         name: "Mock Coin One",
         symbol: "MCO",
         decimals: 8,
         existentialDeposit: 42,
-        feesPerMinute: 15
+        feesPerMinute: 15,
     };
 
     before(() => {
@@ -24,7 +24,7 @@ describe("DefaultAssetRegistryAPI", () => {
         // we only need the instance to create variables
         api.disconnect();
 
-        // register just enough from OrmlAssetRegistryAssetMetadata to construct 
+        // register just enough from OrmlAssetRegistryAssetMetadata to construct
         // meaningful representations for our tests
         api.registerTypes({
             OrmlAssetRegistryAssetMetadata: {
@@ -32,11 +32,11 @@ describe("DefaultAssetRegistryAPI", () => {
                 symbol: "Bytes",
                 decimals: "u32",
                 existentialDeposit: "u128",
-                additional: "InterbtcPrimitivesCustomMetadata"
+                additional: "InterbtcPrimitivesCustomMetadata",
             },
             InterbtcPrimitivesCustomMetadata: {
-                feePerSecond: "u128"
-            }
+                feePerSecond: "u128",
+            },
         });
     });
 
@@ -50,8 +50,8 @@ describe("DefaultAssetRegistryAPI", () => {
             decimals: api.createType("u32", mockMetadataValues.decimals),
             existentialDeposit: api.createType("u128", mockMetadataValues.existentialDeposit),
             additional: api.createType("InterbtcPrimitivesCustomMetadata", {
-                feePerSecond: api.createType("u128", mockMetadataValues.feesPerMinute)
-            })
+                feePerSecond: api.createType("u128", mockMetadataValues.feesPerMinute),
+            }),
         } as OrmlAssetRegistryAssetMetadata;
     });
 
@@ -74,23 +74,20 @@ describe("DefaultAssetRegistryAPI", () => {
                 // one "good" returned value
                 [
                     api.createType("StorageKey<[u32]>", "0x0000000000000001") as StorageKey<[u32]>,
-                    api.createType("Option<OrmlAssetRegistryAssetMetadata>", mockMetadata)
+                    api.createType("Option<OrmlAssetRegistryAssetMetadata>", mockMetadata),
                 ],
                 // one empty option
                 [
                     api.createType("StorageKey<[u32]>", "0x0000000000000002") as StorageKey<[u32]>,
-                    api.createType("Option<OrmlAssetRegistryAssetMetadata>", undefined)
-                ]
+                    api.createType("Option<OrmlAssetRegistryAssetMetadata>", undefined),
+                ],
             ];
 
             sinon.stub(assetRegistryApi, "getAssetRegistryEntries").returns(Promise.resolve(chainDataReturned));
 
             const actual = await assetRegistryApi.getForeignAssetsAsCurrencies();
 
-            expect(actual).to.have.lengthOf(
-                1,
-                `Expected only one currency to be returned, but got ${actual.length}`
-            );
+            expect(actual).to.have.lengthOf(1, `Expected only one currency to be returned, but got ${actual.length}`);
 
             const actualCurrency = actual[0];
             expect(actualCurrency.ticker).to.equal(
@@ -114,27 +111,9 @@ describe("DefaultAssetRegistryAPI", () => {
                 `Expected currency name to be ${mockMetadataValues.name}, but was ${actual.name}`
             );
 
-            expect(actual.base).to.equal(
+            expect(actual.decimals).to.equal(
                 mockMetadataValues.decimals,
-                `Expected currency base to be ${mockMetadataValues.decimals}, but was ${actual.base}`
-            );
-
-            // rawBase should always be zero
-            expect(actual.rawBase).to.equal(
-                0,
-                `Expected currency rawBase to be zero, but was ${actual.rawBase}`
-            );
-            
-            // check atomic units are defined and zero
-            expect(actual.units.atomic).to.exist;
-            expect(actual.units.atomic).to.equal(
-                0,
-                `Expected currency atomic unit value to be zero, but was ${actual.units.atomic}`
-            );
-            // check "main" unit is defined and has expected decimals value
-            expect(actual.units[actual.ticker]).to.equal(
-                actual.base,
-                `Expected currency unit value for ${actual.ticker} to be ${actual.base}, but was ${actual.units[actual.ticker]}`
+                `Expected currency base to be ${mockMetadataValues.decimals}, but was ${actual.decimals}`
             );
         });
     });

--- a/test/unit/utils/rewards.test.ts
+++ b/test/unit/utils/rewards.test.ts
@@ -1,14 +1,14 @@
-import { Currency, Kintsugi, KintsugiAmount, KintsugiUnit, MonetaryAmount } from "@interlay/monetary-js";
+import { Currency, Kintsugi, KintsugiAmount } from "@interlay/monetary-js";
 import { assert } from "chai";
 import Big from "big.js";
-import { GovernanceUnit, newMonetaryAmount, estimateReward } from "../../../src";
+import { newMonetaryAmount, estimateReward, atomicToBaseAmount, ATOMIC_UNIT } from "../../../src";
 
 const WEEK_IN_BLOCKS = 54000;
 const MINIMUM_BLOCK_PERIOD = 6000; // 6s parachain constant
 const MAX_PERIOD = 4838400; // Kintsugi max locking period
 
 describe("Escrow", () => {
-    let kintCurrency: Currency<KintsugiUnit>;
+    let kintCurrency: Currency;
 
     before(async () => {
         kintCurrency = Kintsugi;
@@ -16,15 +16,15 @@ describe("Escrow", () => {
 
     it("should calculate rewards for the first staker with only the amount", () => {
         // user input
-        const amountToLock = new KintsugiAmount(100, "KINT");
+        const amountToLock = new KintsugiAmount(100);
 
         // existing system
         const userStake = new Big(0);
         const totalStake = new Big(0);
-        const blockReward = newMonetaryAmount(1, kintCurrency) as MonetaryAmount<Currency<GovernanceUnit>, GovernanceUnit>;
+        const blockReward = newMonetaryAmount(1, kintCurrency);
         const stakedBalance = {
-            amount: newMonetaryAmount(0, kintCurrency) as MonetaryAmount<Currency<GovernanceUnit>, GovernanceUnit>,
-            endBlock: 0
+            amount: newMonetaryAmount(0, kintCurrency),
+            endBlock: 0,
         };
         const currentBlockNumber = 1000;
 
@@ -55,10 +55,10 @@ describe("Escrow", () => {
         // existing system
         const userStake = new Big(0);
         const totalStake = new Big(0);
-        const blockReward = newMonetaryAmount(1, kintCurrency) as MonetaryAmount<Currency<GovernanceUnit>, GovernanceUnit>;
+        const blockReward = newMonetaryAmount(1, kintCurrency);
         const stakedBalance = {
-            amount: newMonetaryAmount(0, kintCurrency) as MonetaryAmount<Currency<GovernanceUnit>, GovernanceUnit>,
-            endBlock: 0
+            amount: newMonetaryAmount(0, kintCurrency),
+            endBlock: 0,
         };
         const currentBlockNumber = 1000;
 
@@ -82,19 +82,18 @@ describe("Escrow", () => {
         assert.equal(resultTime.apy.toString(), apy);
     });
 
-
     it("should calculate rewards for the first staker with an amount and a locktime extension", () => {
         // user input
-        const amountToLock = new KintsugiAmount(100, "KINT");
+        const amountToLock = new KintsugiAmount(100);
         const blockLockTimeExtension = 5 * WEEK_IN_BLOCKS; // 5 weeks lock
 
         // existing system
         const userStake = new Big(0);
         const totalStake = new Big(0);
-        const blockReward = newMonetaryAmount(1, kintCurrency, true) as MonetaryAmount<Currency<GovernanceUnit>, GovernanceUnit>;
+        const blockReward = newMonetaryAmount(1, kintCurrency);
         const stakedBalance = {
-            amount: newMonetaryAmount(0, kintCurrency) as MonetaryAmount<Currency<GovernanceUnit>, GovernanceUnit>,
-            endBlock: 0
+            amount: newMonetaryAmount(0, kintCurrency),
+            endBlock: 0,
         };
         const currentBlockNumber = 1000;
 
@@ -122,7 +121,10 @@ describe("Escrow", () => {
         );
 
         assert.equal(resultAmountAndTime.amount.toString(), amount.toString());
-        assert.isTrue(resultAmountAndTime.amount.toBig().gt(0), `${resultAmountAndTime.amount.toString()} not greater than 0`);
+        assert.isTrue(
+            resultAmountAndTime.amount.toBig().gt(0),
+            `${resultAmountAndTime.amount.toString()} not greater than 0`
+        );
         assert.equal(resultAmountAndTime.apy.toString(), apy.toBig().toString());
         assert.isTrue(resultAmountAndTime.apy.gt(0), `${resultAmountAndTime.apy.toString()} not greater than 0`);
     });
@@ -135,10 +137,10 @@ describe("Escrow", () => {
         // existing system
         const userStake = new Big(0);
         const totalStake = new Big(20000000);
-        const blockReward = newMonetaryAmount(1, kintCurrency, true) as MonetaryAmount<Currency<GovernanceUnit>, GovernanceUnit>;
+        const blockReward = newMonetaryAmount(1, kintCurrency, true);
         const stakedBalance = {
-            amount: newMonetaryAmount(0, kintCurrency) as MonetaryAmount<Currency<GovernanceUnit>, GovernanceUnit>,
-            endBlock: 0
+            amount: newMonetaryAmount(0, kintCurrency),
+            endBlock: 0,
         };
         const currentBlockNumber = 1000;
 
@@ -216,20 +218,17 @@ describe("Escrow", () => {
         // this user's stake
         const userStake = new Big(0); // this user has 0
         // other users have 100 locked for 5 weeks
-        const totalStake = new KintsugiAmount(100).toBig()
-            .mul(5 * WEEK_IN_BLOCKS);
-        const blockReward = newMonetaryAmount(1, kintCurrency, true) as MonetaryAmount<Currency<GovernanceUnit>, GovernanceUnit>;
+        const totalStake = new KintsugiAmount(100).toBig().mul(5 * WEEK_IN_BLOCKS);
+        const blockReward = newMonetaryAmount(1, kintCurrency, true);
         const stakedBalance = {
-            amount: newMonetaryAmount(0, kintCurrency) as MonetaryAmount<Currency<GovernanceUnit>, GovernanceUnit>,
-            endBlock: 0
+            amount: newMonetaryAmount(0, kintCurrency),
+            endBlock: 0,
         };
         const currentBlockNumber = 1000;
 
         // expected outputs
         // staker gets a share of the rewards
-        const newUserStake = amountToLock.toBig(0)
-            .mul(blockLockTimeExtension)
-            .div(MAX_PERIOD);
+        const newUserStake = amountToLock.toBig(0).mul(blockLockTimeExtension).div(MAX_PERIOD);
         const amount = newUserStake
             .div(newUserStake.add(totalStake)) // new total stake
             .mul(blockReward.toBig())
@@ -239,11 +238,7 @@ describe("Escrow", () => {
         const blocksPerYear = (60 * 60 * 24 * 365 * 1000) / blockTime;
 
         // projects block rewards for 1 year
-        const apy = amount
-            .div(blockLockTimeExtension)
-            .mul(blocksPerYear)
-            .div(amountToLock.toBig())
-            .mul(100);
+        const apy = amount.div(blockLockTimeExtension).mul(blocksPerYear).div(amountToLock.toBig()).mul(100);
 
         const result = estimateReward(
             kintCurrency,
@@ -258,7 +253,7 @@ describe("Escrow", () => {
             blockLockTimeExtension
         );
 
-        assert.equal(result.amount.toString(), amount.round(0, 0).toString());
+        assert.equal(result.amount.toString(), amount.round(kintCurrency.decimals, 0).toString());
         assert.isTrue(result.amount.toBig().gt(0), `${result.amount.toString()} not greater than 0`);
         assert.equal(result.apy.round(0).toString(), apy.round(0).toString());
         assert.isTrue(result.apy.gt(0), `${result.apy.toString()} not greater than 0`);
@@ -266,36 +261,40 @@ describe("Escrow", () => {
 
     it("should calculate rewards for increasing existing stake", () => {
         // user input
-        const amountToLock = new KintsugiAmount(500, "KINT");
+        const baseAmountToLock = atomicToBaseAmount(500, Kintsugi);
+        const amountToLock = new KintsugiAmount(baseAmountToLock);
         const blockLockTimeExtension = 10 * WEEK_IN_BLOCKS; // 10 weeks lock
 
         // existing system
         const currentBlockNumber = 1000;
         // this user's stake is 100
         const stakedBalance = {
-            amount: newMonetaryAmount(100, kintCurrency, true) as MonetaryAmount<Currency<GovernanceUnit>, GovernanceUnit>,
-            endBlock: 5 * WEEK_IN_BLOCKS
+            amount: newMonetaryAmount(100, kintCurrency, true),
+            endBlock: 5 * WEEK_IN_BLOCKS,
         };
-        const userStake = stakedBalance.amount.toBig()
+        const atomicUserStake = stakedBalance.amount
+            .toBig(ATOMIC_UNIT)
             .mul(stakedBalance.endBlock - currentBlockNumber)
             .div(MAX_PERIOD);
         // other users have locked an additional 500 locked for 5 weeks
-        const totalStake = new KintsugiAmount(600, "KINT").toBig()
+        const atomicTotalStake = new KintsugiAmount(atomicToBaseAmount(500, Kintsugi))
+            .toBig(ATOMIC_UNIT)
             .mul(5 * WEEK_IN_BLOCKS)
             .div(MAX_PERIOD);
-        const blockReward = newMonetaryAmount(1, kintCurrency, true) as MonetaryAmount<Currency<GovernanceUnit>, GovernanceUnit>;
+        const blockReward = newMonetaryAmount(1, kintCurrency, true);
 
         // expected outputs
         // staker gets a share of the rewards
         const newLockDuration = stakedBalance.endBlock + blockLockTimeExtension - currentBlockNumber;
-        const newUserStake = stakedBalance.amount.toBig()
-            .add(amountToLock.toBig())
+        const newUserStake = stakedBalance.amount
+            .toBig(ATOMIC_UNIT)
+            .add(amountToLock.toBig(ATOMIC_UNIT))
             .mul(newLockDuration)
             .div(MAX_PERIOD);
-        const userStakeDifference = newUserStake.sub(userStake);
+        const userStakeDifference = newUserStake.sub(atomicUserStake);
         const amount = blockReward
             .mul(newUserStake) // user stake
-            .div(userStakeDifference.add(totalStake)) // new total stake
+            .div(userStakeDifference.add(atomicTotalStake)) // new total stake
             .mul(newLockDuration);
         // projects block rewards for 1 year
         const apy = amount
@@ -303,13 +302,13 @@ describe("Escrow", () => {
             .div(newLockDuration)
             .mul(60 * 60 * 24 * 365 * 1000) // ms per year
             .div(MINIMUM_BLOCK_PERIOD * 2)
-            .div(stakedBalance.amount.toBig().add(amountToLock.toBig()))
+            .div(stakedBalance.amount.add(amountToLock).toBig())
             .mul(100);
 
         const result = estimateReward(
             kintCurrency,
-            userStake,
-            totalStake,
+            atomicUserStake,
+            atomicTotalStake,
             blockReward,
             stakedBalance,
             currentBlockNumber,
@@ -328,25 +327,27 @@ describe("Escrow", () => {
     it("should calculate rewards for current staked amounts", () => {
         // existing system
         const currentBlockNumber = 1000;
-        const blockReward = newMonetaryAmount(1, kintCurrency, true) as MonetaryAmount<Currency<GovernanceUnit>, GovernanceUnit>;
+        const blockReward = newMonetaryAmount(1, kintCurrency, true);
         const stakedBalance = {
-            amount: newMonetaryAmount(100, kintCurrency, true) as MonetaryAmount<Currency<GovernanceUnit>, GovernanceUnit>,
-            endBlock: 5 * WEEK_IN_BLOCKS
+            amount: newMonetaryAmount(100, kintCurrency, true),
+            endBlock: 5 * WEEK_IN_BLOCKS,
         };
         // this user's stake is 100
-        const userStake = stakedBalance.amount.toBig()
+        const atomicUserStake = stakedBalance.amount
+            .toBig(ATOMIC_UNIT)
             .mul(stakedBalance.endBlock - currentBlockNumber)
             .div(MAX_PERIOD);
         // other users have locked an additional 500 locked for 5 weeks
-        const totalStake = new KintsugiAmount(600, "KINT").toBig()
+        const atomicTotalStake = new KintsugiAmount(600)
+            .toBig(ATOMIC_UNIT)
             .mul(5 * WEEK_IN_BLOCKS)
             .div(MAX_PERIOD);
 
         // expected outputs
         // staker gets a share of the rewards
         const amount = blockReward
-            .mul(userStake) // user stake
-            .div(totalStake) // total stake
+            .mul(atomicUserStake) // user stake
+            .div(atomicTotalStake) // total stake
             .mul(stakedBalance.endBlock - currentBlockNumber);
         // projects block rewards for 1 year
         const apy = amount
@@ -359,8 +360,8 @@ describe("Escrow", () => {
 
         const result = estimateReward(
             kintCurrency,
-            userStake,
-            totalStake,
+            atomicUserStake,
+            atomicTotalStake,
             blockReward,
             stakedBalance,
             currentBlockNumber,

--- a/test/utils/helpers.ts
+++ b/test/utils/helpers.ts
@@ -1,5 +1,5 @@
 import { Transaction } from "@interlay/esplora-btc-api";
-import { Bitcoin, BitcoinUnit, Currency, ExchangeRate, UnitList } from "@interlay/monetary-js";
+import { Bitcoin, Currency, ExchangeRate } from "@interlay/monetary-js";
 import { Keyring } from "@polkadot/api";
 import { ApiTypes, AugmentedEvent } from "@polkadot/api/types";
 import { KeyringPair } from "@polkadot/keyring/types";
@@ -7,14 +7,7 @@ import { AnyTuple } from "@polkadot/types/types";
 import { mnemonicGenerate } from "@polkadot/util-crypto";
 import Big, { RoundingMode } from "big.js";
 import * as bitcoinjs from "bitcoinjs-lib";
-import {
-    BitcoinCoreClient,
-    InterBtcApi,
-    CollateralUnit,
-    OracleAPI,
-    VaultStatusExt,
-    DefaultTransactionAPI,
-} from "../../src";
+import { BitcoinCoreClient, InterBtcApi, OracleAPI, VaultStatusExt, DefaultTransactionAPI } from "../../src";
 import { SUDO_URI } from "../config";
 
 export const SLEEP_TIME_MS = 1000;
@@ -37,9 +30,9 @@ export async function wait_success<R>(call: () => Promise<R>): Promise<R> {
     }
 }
 
-export async function callWithExchangeRate<C extends CollateralUnit>(
+export async function callWithExchangeRate(
     oracleAPI: OracleAPI,
-    exchangeRate: ExchangeRate<Bitcoin, BitcoinUnit, Currency<C>, C>,
+    exchangeRate: ExchangeRate<Bitcoin, Currency>,
     fn: () => Promise<void>
 ): Promise<void> {
     const initialExchangeRate = await oracleAPI.getExchangeRate(exchangeRate.counter);
@@ -129,8 +122,7 @@ export const vaultStatusToLabel = (status: VaultStatusExt): string => {
 // use the same exchange rate as the running oracles use
 // to avoid flaky tests due to updated prices from the oracle client(s)
 // note: currently the same for all collateral currencies - might change in future
-export const getExchangeRateValueToSetForTesting = <U extends UnitList>(_collateralCurrency: Currency<U>): Big =>
-    new Big("230.0");
+export const getExchangeRateValueToSetForTesting = (_collateralCurrency: Currency): Big => new Big("230.0");
 
 /**
  * Returns the vsize (virtual size) of the given transaction.


### PR DESCRIPTION
This PR includes the work to:

- bump monetary version to 0.7.0, 
- remove currency units, and 
- fix compiler/typescript errors

The related work to add foreign assets from the asset registry as collateral currencies will be provided in a stacked PR.

-------
For reference: Notable breaking changes from monetary introduced with 0.7.0
- `MonetaryAmount.toBig()` defaults to returning the base unit amount instead of the atomic unit. ie. for Bitcoin the BTC amount, instead of Satoshi
   To access Satoshi, we can pass in a unit (0 is the "atomic unit", Satoshi in this example.)
- `MonetaryAmount.toString()` now defaults to returning the amount in the base unit instead of the atomic unit. Also, the signature has changed from taking optional units to an optional boolean `atomic` flag. ie. `MonetaryAmount.toString(true)` will return the amount as string in atomic units (Satoshi in the example of Bitcoin.)
- The previous property `MonetaryAmount.zero` has changed to a method, `MonetaryAmount.zero()`