### PR TITLE
Feat: Add foreign asset model as valid currency to lib

### DIFF
--- a/.github/workflows/integration-tests-kint.yml
+++ b/.github/workflows/integration-tests-kint.yml
@@ -4,6 +4,7 @@ on:
     pull_request:
         branches:
             - master
+            - brendon/feat-add-foreign-asset-model
 
 concurrency:
     group: ${{ github.ref }}_kint

--- a/src/clients/faucet.ts
+++ b/src/clients/faucet.ts
@@ -4,9 +4,9 @@ import { TypeRegistry } from "@polkadot/types";
 import { Constructor } from "@polkadot/types/types";
 import { AccountId } from "@polkadot/types/interfaces";
 import { JsonRpcClient } from "./client";
-import { CollateralIdLiteral } from "../types";
 import { newCurrencyId } from "../utils";
 import { ApiPromise } from "@polkadot/api";
+import { CollateralCurrencyExt } from "../types";
 
 /**
  * @category Clients
@@ -28,8 +28,8 @@ export class FaucetClient extends JsonRpcClient<void> {
         };
     }
 
-    async fundAccount(account: AccountId, currencyIdLiteral: CollateralIdLiteral): Promise<void> {
-        const currencyId = newCurrencyId(this.api, currencyIdLiteral);
+    async fundAccount(account: AccountId, currency: CollateralCurrencyExt): Promise<void> {
+        const currencyId = newCurrencyId(this.api, currency);
         const request = new this.constr["FundAccountJsonRpcRequest"](this.registry, {
             account_id: account,
             currency_id: currencyId,

--- a/src/parachain/asset-registry.ts
+++ b/src/parachain/asset-registry.ts
@@ -1,9 +1,11 @@
 import { Currency } from "@interlay/monetary-js";
 import { ApiPromise } from "@polkadot/api";
 import { StorageKey, u32 } from "@polkadot/types";
+import { AssetId } from "@polkadot/types/interfaces/runtime";
 import { OrmlAssetRegistryAssetMetadata } from "@polkadot/types/lookup";
-import { decodeBytesAsString } from "../utils";
+import { decodeBytesAsString, newForeignAssetId, storageKeyToNthInner } from "../utils";
 import { Option } from "@polkadot/types-codec";
+import { ForeignAsset } from "../types";
 
 /**
  * @category BTC Bridge
@@ -13,24 +15,41 @@ export interface AssetRegistryAPI {
      * Get all currencies (foreign assets) in the asset registry.
      * @returns A list of currencies.
      */
-    getForeignAssetsAsCurrencies(): Promise<Array<Currency>>;
+    getForeignAssets(): Promise<Array<ForeignAsset>>;
+
+    /**
+     * Get foreign asset by its id.
+     * @param id The id of the foreign asset.
+     * @returns The foreign asset.
+     */
+    getForeignAsset(id: number | u32): Promise<ForeignAsset>;
 }
 
 // shorthand type for the unwieldy tuple
 export type AssetRegistryMetadataTuple = [StorageKey<[u32]>, Option<OrmlAssetRegistryAssetMetadata>];
+export type UnwrappedAssetRegistryMetadataTuple = [StorageKey<[u32]>, OrmlAssetRegistryAssetMetadata];
 
 export class DefaultAssetRegistryAPI {
     constructor(private api: ApiPromise) {}
 
-    // not private for easier testing
     static metadataToCurrency(metadata: OrmlAssetRegistryAssetMetadata): Currency {
         const symbol = decodeBytesAsString(metadata.symbol);
         const name = decodeBytesAsString(metadata.name);
-
         return {
             name: name,
-            decimals: metadata.decimals.toNumber(),
             ticker: symbol,
+            decimals: metadata.decimals.toNumber(),
+        };
+    }
+
+    // not private for easier testing
+    static metadataTupleToForeignAsset([key, metadata]: UnwrappedAssetRegistryMetadataTuple): ForeignAsset {
+        const keyInner = storageKeyToNthInner<AssetId>(key);
+        const currencyPart = DefaultAssetRegistryAPI.metadataToCurrency(metadata);
+
+        return {
+            id: keyInner.toNumber(),
+            ...currencyPart,
         };
     }
 
@@ -40,20 +59,38 @@ export class DefaultAssetRegistryAPI {
     }
 
     /**
-     * Static method to grab onle metadata from entries provided by the asset registry.
-     * Ignores entries with no metadata (ie. `Option.isSome !== true`).
+     * Static method to filter out metadata that can be unwrapped.ie. `Option.isSome !== true`.
      * @param entries The entries from the asset registry.
-     * @returns A list of metadata.
+     * @returns A list of all entries containing metadata.
      */
-    static extractMetadataFromEntries(entries: AssetRegistryMetadataTuple[]): OrmlAssetRegistryAssetMetadata[] {
-        return entries.filter(([, metadata]) => metadata.isSome).map(([, metadata]) => metadata.unwrap());
+    static unwrapMetadataFromEntries(entries: AssetRegistryMetadataTuple[]): UnwrappedAssetRegistryMetadataTuple[] {
+        return entries
+            .filter(([, metadata]) => metadata.isSome)
+            .map(([storageKey, metadata]) => [storageKey, metadata.unwrap()]);
     }
 
-    async getForeignAssetsAsCurrencies(): Promise<Array<Currency>> {
+    async getForeignAssets(): Promise<Array<ForeignAsset>> {
         const entries = await this.getAssetRegistryEntries();
 
-        return DefaultAssetRegistryAPI.extractMetadataFromEntries(entries).map(
-            DefaultAssetRegistryAPI.metadataToCurrency
+        return DefaultAssetRegistryAPI.unwrapMetadataFromEntries(entries).map(
+            DefaultAssetRegistryAPI.metadataTupleToForeignAsset
         );
+    }
+
+    async getForeignAsset(id: number | u32): Promise<ForeignAsset> {
+        const u32Id = id instanceof u32 ? id : newForeignAssetId(this.api, id);
+        const optionMetadata = await this.api.query.assetRegistry.metadata(u32Id);
+
+        if (!optionMetadata.isSome) {
+            return Promise.reject(new Error("Foreign asset not found"));
+        }
+        const currencyPart = DefaultAssetRegistryAPI.metadataToCurrency(optionMetadata.unwrap());
+
+        const numberId = id instanceof u32 ? id.toNumber() : id;
+
+        return {
+            id: numberId,
+            ...currencyPart,
+        };
     }
 }

--- a/src/parachain/escrow.ts
+++ b/src/parachain/escrow.ts
@@ -18,7 +18,6 @@ import {
     parseEscrowPoint,
     RWEscrowPoint,
     StakedBalance,
-    tickerToCurrencyIdLiteral,
     VotingCurrency,
 } from "../types";
 import { SystemAPI } from "./system";
@@ -198,13 +197,13 @@ export class DefaultEscrowAPI implements EscrowAPI {
     }
 
     async getRewardTally(accountId: AccountId): Promise<Big> {
-        const governanceCurrencyId = newCurrencyId(this.api, tickerToCurrencyIdLiteral(this.governanceCurrency.ticker));
+        const governanceCurrencyId = newCurrencyId(this.api, this.governanceCurrency);
         const rawRewardTally = await this.api.query.escrowRewards.rewardTally(governanceCurrencyId, accountId);
         return decodeFixedPointType(rawRewardTally);
     }
 
     async getRewardPerToken(): Promise<Big> {
-        const governanceCurrencyId = newCurrencyId(this.api, tickerToCurrencyIdLiteral(this.governanceCurrency.ticker));
+        const governanceCurrencyId = newCurrencyId(this.api, this.governanceCurrency);
         const rawRewardPerToken = await this.api.query.escrowRewards.rewardPerToken(governanceCurrencyId);
         return decodeFixedPointType(rawRewardPerToken);
     }

--- a/src/parachain/fee.ts
+++ b/src/parachain/fee.ts
@@ -5,7 +5,7 @@ import { Bitcoin, ExchangeRate, MonetaryAmount } from "@interlay/monetary-js";
 
 import { decodeFixedPointType } from "../utils/encoding";
 import { CollateralCurrencyExt, CurrencyExt, WrappedCurrency } from "../types";
-import { AssetRegistryAPI } from "..";
+import { AssetRegistryAPI } from "../parachain/asset-registry";
 import { currencyIdToMonetaryCurrency } from "../utils";
 
 export enum GriefingCollateralType {

--- a/src/parachain/issue.ts
+++ b/src/parachain/issue.ts
@@ -25,7 +25,8 @@ import { FeeAPI } from "./fee";
 import { ElectrsAPI } from "../external";
 import { TransactionAPI } from "./transaction";
 import { CollateralCurrencyExt, Issue, WrappedCurrency } from "../types";
-import { AssetRegistryAPI, currencyIdToMonetaryCurrency } from "..";
+import { AssetRegistryAPI } from "../parachain/asset-registry";
+import { currencyIdToMonetaryCurrency } from "../utils";
 
 export type IssueLimits = {
     singleVaultMaxIssuable: MonetaryAmount<WrappedCurrency>;

--- a/src/parachain/nomination.ts
+++ b/src/parachain/nomination.ts
@@ -17,7 +17,8 @@ import { TransactionAPI } from "./transaction";
 import { CollateralCurrencyExt, NominationStatus, WrappedCurrency } from "../types";
 import { RewardsAPI } from "./rewards";
 import { UnsignedFixedPoint } from "../interfaces";
-import { AssetRegistryAPI, currencyIdToMonetaryCurrency } from "..";
+import { AssetRegistryAPI } from "../parachain/asset-registry";
+import { currencyIdToMonetaryCurrency } from "../utils/currency";
 
 export enum NominationAmountType {
     Raw = "raw",

--- a/src/parachain/redeem.ts
+++ b/src/parachain/redeem.ts
@@ -30,7 +30,7 @@ import { ElectrsAPI } from "../external";
 import { TransactionAPI } from "./transaction";
 import { OracleAPI } from "./oracle";
 import { CollateralCurrencyExt, Redeem, WrappedCurrency } from "../types";
-import { AssetRegistryAPI } from "..";
+import { AssetRegistryAPI } from "../parachain/asset-registry";
 
 /**
  * @category BTC Bridge

--- a/src/parachain/rewards.ts
+++ b/src/parachain/rewards.ts
@@ -3,137 +3,131 @@ import { Currency, MonetaryAmount } from "@interlay/monetary-js";
 import { ApiPromise } from "@polkadot/api/promise";
 import Big from "big.js";
 
-import { computeLazyDistribution, decodeFixedPointType, newCurrencyId, newMonetaryAmount, newVaultId } from "../utils";
-import { InterbtcPrimitivesVaultId } from "../parachain";
-import { TransactionAPI } from "../parachain/transaction";
 import {
-    tickerToCurrencyIdLiteral,
-    CurrencyIdLiteral,
-    CollateralCurrency,
-    CollateralIdLiteral,
+    computeLazyDistribution,
     currencyIdToMonetaryCurrency,
-    WrappedCurrency,
-    WrappedIdLiteral,
-    currencyIdToLiteral,
-    currencyIdLiteralToMonetaryCurrency,
-    GovernanceIdLiteral,
-    GovernanceCurrency,
-} from "../types";
+    decodeFixedPointType,
+    newCurrencyId,
+    newMonetaryAmount,
+    newVaultId,
+} from "../utils";
+import { AssetRegistryAPI, InterbtcPrimitivesVaultId } from "../parachain";
+import { TransactionAPI } from "../parachain/transaction";
+import { WrappedCurrency, GovernanceCurrency, CollateralCurrencyExt, CurrencyExt } from "../types";
 
 export interface RewardsAPI {
     /**
      * @param vaultId The account ID of the staking pool nominee
      * @param nominatorId The account ID of the staking pool nominator
-     * @param collateralCurrencyId Collateral currency used by the vault
+     * @param collateralCurrency Collateral currency used by the vault
      * @returns A Monetary.js amount object, representing the reward in the given currency
      */
     computeRewardInStakingPool(
         vaultAccountId: AccountId,
         nominatorId: AccountId,
-        collateralCurrencyId: CollateralIdLiteral,
-        rewardCurrencyId?: CurrencyIdLiteral,
+        collateralCurrenc: CollateralCurrencyExt,
+        rewardCurrency?: CurrencyExt,
         nonce?: number
-    ): Promise<MonetaryAmount<Currency>>;
+    ): Promise<MonetaryAmount<CurrencyExt>>;
     /**
-     * @param collateralCurrencyId The staked currency
+     * @param collateralCurrency The staked currency
      * @param vaultId The account ID of the staking pool nominee
      * @param nominatorId The account ID of the staking pool nominator
      * @returns The stake, as a Big object
      */
     getStakingPoolStake(
-        collateralCurrencyId: CollateralIdLiteral,
+        collateralCurrency: CollateralCurrencyExt,
         vaultId: AccountId,
         nominatorId: AccountId
     ): Promise<Big>;
     /**
      * Total stake for a vault
-     * @param collateralCurrencyIdLiteral The vault's collateral
+     * @param collateralCurrency The vault's collateral
      * @param vaultAccountId The vault's accountID
      * @param nonce The nonce of the rewards pool
      * @returns The stake, as a Big object
      */
     getStakingPoolTotalStake(
-        collateralCurrencyIdLiteral: CollateralIdLiteral,
+        collateralCurrencyIdLiteral: CollateralCurrencyExt,
         vaultAccountId: AccountId,
         nonce?: number
     ): Promise<Big>;
     /**
-     * @param rewardCurrencyId The reward currency, e.g. kBTC, KINT, interBTC, INTR
+     * @param rewardCurrency The reward currency, e.g. kBTC, KINT, interBTC, INTR
      * @param vaultId The account ID of the staking pool nominee
      * @param nominatorId The account ID of the staking pool nominator
-     * @param collateralCurrencyId Collateral currency used by the vault
+     * @param collateralCurrency Collateral currency used by the vault
      * @param nonce Nonce of the rewards pool
      * @returns The reward tally, as a Big object
      */
     getStakingPoolRewardTally(
-        rewardCurrencyId: CurrencyIdLiteral,
+        rewardCurrency: Currency,
         vaultId: AccountId,
         nominatorId: AccountId,
-        collateralCurrencyId: CollateralIdLiteral,
+        collateralCurrency: CollateralCurrencyExt,
         nonce?: number
     ): Promise<Big>;
     /**
-     * @param rewardCurrencyId The reward currency, e.g. kBTC, KINT, interBTC, INTR
+     * @param rewardCurrency The reward currency, e.g. kBTC, KINT, interBTC, INTR
      * @param vaultId The account ID of the staking pool nominee
-     * @param collateralCurrencyId Collateral currency used by the vault
+     * @param collateralCurrency Collateral currency used by the vault
      * @param nonce Nonce of the rewards pool
      * @returns The reward per token, as a Big object
      */
     getStakingPoolRewardPerToken(
-        rewardCurrencyId: CurrencyIdLiteral,
+        rewardCurrency: Currency,
         vaultId: AccountId,
-        collateralCurrencyId: CollateralIdLiteral,
+        collateralCurrency: CollateralCurrencyExt,
         nonce?: number
     ): Promise<Big>;
     /**
-     * @param currencyId The staked currency
+     * @param currency The staked currency
      * @param vaultId The account ID of the staking pool nominee
      * @returns The current nonce of the staking pool
      */
-    getStakingPoolNonce(currencyId: CollateralIdLiteral, vaultId: AccountId): Promise<number>;
+    getStakingPoolNonce(currency: CurrencyExt, vaultId: AccountId): Promise<number>;
     /**
-     * @param rewardCurrencyIdLiteral The reward currency
-     * @param vaultCollateralIdLiteral Collateral used by the vault
+     * @param rewardCurrency The reward currency
+     * @param vaultCollateral Collateral used by the vault
      * @param vaultAccountId The vault ID whose reward to compute
      * @returns A Monetary.js amount object, representing the reward in the given currency
      */
     computeRewardInRewardsPool(
-        rewardCurrencyIdLiteral: CurrencyIdLiteral,
-        vaultCollateralIdLiteral: CollateralIdLiteral,
+        rewardCurrencyIdLiteral: Currency,
+        vaultCollateralIdLiteral: CollateralCurrencyExt,
         vaultAccountId: AccountId
     ): Promise<MonetaryAmount<Currency>>;
     /**
      * @param vaultId The account ID of the staking pool nominee
      * @param nominatorId The account ID of the staking pool nominator
-     * @param collateralCurrencyIdLiteral Collateral used by the vault
      * @returns A Monetary.js amount object, representing the collateral in the given currency
      */
     computeCollateralInStakingPool(
         vaultId: InterbtcPrimitivesVaultId,
         nominatorId: AccountId
-    ): Promise<MonetaryAmount<CollateralCurrency>>;
+    ): Promise<MonetaryAmount<CollateralCurrencyExt>>;
     /**
-     * @param currencyId The reward currency
+     * @param currency The reward currency
      * @param accountId An account ID string
      * @returns The stake, as a Big object
      */
-    getRewardsPoolStake(currencyId: CurrencyIdLiteral, accountId: AccountId): Promise<Big>;
+    getRewardsPoolStake(currency: Currency, accountId: AccountId): Promise<Big>;
     /**
-     * @param rewardCurrencyIdLiteral The reward currency
-     * @param vaultCollateralIdLiteral Collateral used by the vault
+     * @param rewardCurrency The reward currency
+     * @param vaultCollateral Collateral used by the vault
      * @param vaultAccountId The vault ID whose reward pool to check
      * @returns The reward tally, as a Big object
      */
     getRewardsPoolRewardTally(
-        rewardCurrencyIdLiteral: CurrencyIdLiteral,
-        vaultCollateralIdLiteral: CollateralIdLiteral,
+        rewardCurrencyIdLiteral: Currency,
+        vaultCollateralIdLiteral: CollateralCurrencyExt,
         vaultAccountId: AccountId
     ): Promise<Big>;
     /**
-     * @param currencyId The reward currency
+     * @param currency The reward currency
      * @returns The reward per token, as a Big object
      */
-    getRewardsPoolRewardPerToken(currencyId: CurrencyIdLiteral): Promise<Big>;
+    getRewardsPoolRewardPerToken(currencyId: Currency): Promise<Big>;
     /**
      * @param vaultId VaultId object
      * @param nonce Staking pool nonce
@@ -145,21 +139,22 @@ export interface RewardsAPI {
      * Gets the vault annuity systemwide per-block reward.
      * @param governanceCurrency The ID of the currency the reward is paid out in.
      */
-    getRewardPerBlock(governanceCurrency: GovernanceIdLiteral): Promise<MonetaryAmount<GovernanceCurrency>>;
+    getRewardPerBlock(governanceCurrency: GovernanceCurrency): Promise<MonetaryAmount<GovernanceCurrency>>;
 }
 
 export class DefaultRewardsAPI implements RewardsAPI {
     constructor(
         public api: ApiPromise,
         private wrappedCurrency: WrappedCurrency,
-        private transactionAPI: TransactionAPI
+        private transactionAPI: TransactionAPI,
+        private assetRegistry: AssetRegistryAPI
     ) {}
 
     async withdrawRewards(vaultId: InterbtcPrimitivesVaultId, nonce?: number): Promise<void> {
         const definedNonce = nonce
             ? nonce
             : await this.getStakingPoolNonce(
-                  currencyIdToLiteral(vaultId.currencies.collateral) as CollateralIdLiteral,
+                  await currencyIdToMonetaryCurrency(this.assetRegistry, vaultId.currencies.collateral),
                   vaultId.accountId
               );
         const tx = this.api.tx.fee.withdrawRewards(vaultId, definedNonce.toString());
@@ -169,102 +164,82 @@ export class DefaultRewardsAPI implements RewardsAPI {
     async computeRewardInStakingPool(
         vaultAccountId: AccountId,
         nominatorId: AccountId,
-        collateralCurrencyId: CollateralIdLiteral,
-        rewardCurrencyId?: CurrencyIdLiteral,
+        collateralCurrency: CollateralCurrencyExt,
+        rewardCurrency?: Currency,
         nonce?: number
     ): Promise<MonetaryAmount<Currency>> {
-        const wrappedCurrencyId = tickerToCurrencyIdLiteral(this.wrappedCurrency.ticker) as WrappedIdLiteral;
-        rewardCurrencyId = (rewardCurrencyId ? rewardCurrencyId : wrappedCurrencyId) as CurrencyIdLiteral;
+        rewardCurrency = rewardCurrency || this.wrappedCurrency;
         const [stake, rewardPerToken, rewardTally] = await Promise.all([
-            this.getStakingPoolStake(collateralCurrencyId, vaultAccountId, nominatorId, nonce),
-            this.getStakingPoolRewardPerToken(rewardCurrencyId, vaultAccountId, collateralCurrencyId, nonce),
-            this.getStakingPoolRewardTally(rewardCurrencyId, vaultAccountId, nominatorId, collateralCurrencyId, nonce),
+            this.getStakingPoolStake(collateralCurrency, vaultAccountId, nominatorId, nonce),
+            this.getStakingPoolRewardPerToken(rewardCurrency, vaultAccountId, collateralCurrency, nonce),
+            this.getStakingPoolRewardTally(rewardCurrency, vaultAccountId, nominatorId, collateralCurrency, nonce),
         ]);
         const rawLazyDistribution = computeLazyDistribution(stake, rewardPerToken, rewardTally);
-        return newMonetaryAmount(rawLazyDistribution, currencyIdLiteralToMonetaryCurrency(this.api, rewardCurrencyId));
+        return newMonetaryAmount(rawLazyDistribution, rewardCurrency);
     }
 
-    async getStakingPoolNonce(
-        collateralCurrencyIdLiteral: CollateralIdLiteral,
-        vaultAccountId: AccountId
-    ): Promise<number> {
-        const collateralCurrency = currencyIdToMonetaryCurrency(
-            newCurrencyId(this.api, collateralCurrencyIdLiteral)
-        ) as CollateralCurrency;
+    async getStakingPoolNonce(collateralCurrency: CollateralCurrencyExt, vaultAccountId: AccountId): Promise<number> {
         const vaultId = newVaultId(this.api, vaultAccountId.toString(), collateralCurrency, this.wrappedCurrency);
         const rawNonce = await this.api.query.vaultStaking.nonce(vaultId);
         return rawNonce.toNumber();
     }
 
     async getStakingPoolStake(
-        collateralCurrencyIdLiteral: CollateralIdLiteral,
+        collateralCurrency: CollateralCurrencyExt,
         vaultAccountId: AccountId,
         nominatorId: AccountId,
         nonce?: number
     ): Promise<Big> {
         if (nonce === undefined) {
-            nonce = await this.getStakingPoolNonce(collateralCurrencyIdLiteral, vaultAccountId);
+            nonce = await this.getStakingPoolNonce(collateralCurrency, vaultAccountId);
         }
-        const collateralCurrency = currencyIdToMonetaryCurrency(
-            newCurrencyId(this.api, collateralCurrencyIdLiteral)
-        ) as CollateralCurrency;
         const vaultId = newVaultId(this.api, vaultAccountId.toString(), collateralCurrency, this.wrappedCurrency);
         const rawStake = await this.api.query.vaultStaking.stake(nonce, [vaultId, nominatorId]);
         return decodeFixedPointType(rawStake);
     }
 
     async getStakingPoolTotalStake(
-        collateralCurrencyIdLiteral: CollateralIdLiteral,
+        collateralCurrency: CollateralCurrencyExt,
         vaultAccountId: AccountId,
         nonce?: number
     ): Promise<Big> {
         if (nonce === undefined) {
-            nonce = await this.getStakingPoolNonce(collateralCurrencyIdLiteral, vaultAccountId);
+            nonce = await this.getStakingPoolNonce(collateralCurrency, vaultAccountId);
         }
-        const collateralCurrency = currencyIdToMonetaryCurrency(
-            newCurrencyId(this.api, collateralCurrencyIdLiteral)
-        ) as CollateralCurrency;
         const vaultId = newVaultId(this.api, vaultAccountId.toString(), collateralCurrency, this.wrappedCurrency);
         const rawTotalStake = await this.api.query.vaultStaking.totalCurrentStake(nonce, vaultId);
         return decodeFixedPointType(rawTotalStake);
     }
 
     async getStakingPoolRewardTally(
-        rewardCurrencyIdLiteral: CurrencyIdLiteral,
+        rewardCurrency: Currency,
         vaultAccountId: AccountId,
         nominatorId: AccountId,
-        collateralCurrencyIdLiteral: CollateralIdLiteral,
+        collateralCurrency: CollateralCurrencyExt,
         nonce?: number
     ): Promise<Big> {
         if (nonce === undefined) {
-            nonce = await this.getStakingPoolNonce(collateralCurrencyIdLiteral, vaultAccountId);
+            nonce = await this.getStakingPoolNonce(collateralCurrency, vaultAccountId);
         }
-        const collateralCurrency = currencyIdLiteralToMonetaryCurrency(
-            this.api,
-            collateralCurrencyIdLiteral
-        ) as CollateralCurrency;
-        const rewardCurrency = newCurrencyId(this.api, rewardCurrencyIdLiteral);
+        const rewardCurrencyPrimitive = newCurrencyId(this.api, rewardCurrency);
         const vaultId = newVaultId(this.api, vaultAccountId.toString(), collateralCurrency, this.wrappedCurrency);
         return decodeFixedPointType(
-            await this.api.query.vaultStaking.rewardTally(rewardCurrency, [nonce, vaultId, nominatorId])
+            await this.api.query.vaultStaking.rewardTally(rewardCurrencyPrimitive, [nonce, vaultId, nominatorId])
         );
     }
 
     async getStakingPoolRewardPerToken(
-        wrappedCurrencyIdLiteral: CurrencyIdLiteral,
+        wrappedCurrency: Currency,
         vaultAccountId: AccountId,
-        collateralCurrencyIdLiteral: CollateralIdLiteral,
+        collateralCurrency: CollateralCurrencyExt,
         nonce?: number
     ): Promise<Big> {
         if (nonce === undefined) {
-            nonce = await this.getStakingPoolNonce(collateralCurrencyIdLiteral, vaultAccountId);
+            nonce = await this.getStakingPoolNonce(collateralCurrency, vaultAccountId);
         }
-        const collateralCurrency = currencyIdToMonetaryCurrency(
-            newCurrencyId(this.api, collateralCurrencyIdLiteral)
-        ) as CollateralCurrency;
         const vaultId = newVaultId(this.api, vaultAccountId.toString(), collateralCurrency, this.wrappedCurrency);
 
-        const wrappedCurrencyId = newCurrencyId(this.api, wrappedCurrencyIdLiteral);
+        const wrappedCurrencyId = newCurrencyId(this.api, wrappedCurrency);
         return decodeFixedPointType(
             await this.api.query.vaultStaking.rewardPerToken(wrappedCurrencyId, [nonce, vaultId])
         );
@@ -273,101 +248,92 @@ export class DefaultRewardsAPI implements RewardsAPI {
     async computeCollateralInStakingPool(
         vaultId: InterbtcPrimitivesVaultId,
         nominatorId: AccountId
-    ): Promise<MonetaryAmount<CollateralCurrency>> {
-        const collateralCurrencyIdLiteral = currencyIdToLiteral(vaultId.currencies.collateral) as CollateralIdLiteral;
+    ): Promise<MonetaryAmount<CollateralCurrencyExt>> {
+        const collateralCurrency = await currencyIdToMonetaryCurrency(
+            this.assetRegistry,
+            vaultId.currencies.collateral
+        );
         const [stake, slashPerToken, slashTally] = await Promise.all([
-            this.getStakingPoolStake(collateralCurrencyIdLiteral, vaultId.accountId, nominatorId),
-            this.getStakingPoolSlashPerToken(collateralCurrencyIdLiteral, vaultId.accountId),
-            this.getStakingPoolSlashTally(collateralCurrencyIdLiteral, vaultId.accountId, nominatorId),
+            this.getStakingPoolStake(collateralCurrency, vaultId.accountId, nominatorId),
+            this.getStakingPoolSlashPerToken(collateralCurrency, vaultId.accountId),
+            this.getStakingPoolSlashTally(collateralCurrency, vaultId.accountId, nominatorId),
         ]);
         const toSlash = computeLazyDistribution(stake, slashPerToken, slashTally);
-        return newMonetaryAmount(stake.sub(toSlash), currencyIdToMonetaryCurrency(vaultId.currencies.collateral));
+        return newMonetaryAmount(
+            stake.sub(toSlash),
+            await currencyIdToMonetaryCurrency(this.assetRegistry, vaultId.currencies.collateral)
+        );
     }
 
     async getStakingPoolSlashPerToken(
-        vaultCollateralIdLiteral: CollateralIdLiteral,
+        vaultCollateral: CollateralCurrencyExt,
         vaultAccountId: AccountId,
         nonce?: number
     ): Promise<Big> {
         if (nonce === undefined) {
-            nonce = await this.getStakingPoolNonce(vaultCollateralIdLiteral, vaultAccountId);
+            nonce = await this.getStakingPoolNonce(vaultCollateral, vaultAccountId);
         }
-        const collateralCurrency = currencyIdToMonetaryCurrency(
-            newCurrencyId(this.api, vaultCollateralIdLiteral)
-        ) as CollateralCurrency;
-        const vaultId = newVaultId(this.api, vaultAccountId.toString(), collateralCurrency, this.wrappedCurrency);
+        const vaultId = newVaultId(this.api, vaultAccountId.toString(), vaultCollateral, this.wrappedCurrency);
         return decodeFixedPointType(await this.api.query.vaultStaking.slashPerToken(nonce, vaultId));
     }
 
     async getStakingPoolSlashTally(
-        collateralCurrencyIdLiteral: CollateralIdLiteral,
+        collateralCurrency: CollateralCurrencyExt,
         vaultAccountId: AccountId,
         nominatorId: AccountId,
         nonce?: number
     ): Promise<Big> {
         if (nonce === undefined) {
-            nonce = await this.getStakingPoolNonce(collateralCurrencyIdLiteral, vaultAccountId);
+            nonce = await this.getStakingPoolNonce(collateralCurrency, vaultAccountId);
         }
-        const collateralCurrency = currencyIdToMonetaryCurrency(
-            newCurrencyId(this.api, collateralCurrencyIdLiteral)
-        ) as CollateralCurrency;
         const vaultId = newVaultId(this.api, vaultAccountId.toString(), collateralCurrency, this.wrappedCurrency);
 
         return decodeFixedPointType(await this.api.query.vaultStaking.slashTally(nonce, [vaultId, nominatorId]));
     }
 
     async computeRewardInRewardsPool(
-        rewardCurrencyIdLiteral: CurrencyIdLiteral,
-        vaultCollateralIdLiteral: CollateralIdLiteral,
+        rewardCurrency: Currency,
+        vaultCollateral: CollateralCurrencyExt,
         vaultAccountId: AccountId
     ): Promise<MonetaryAmount<Currency>> {
-        const stake = await this.getRewardsPoolStake(vaultCollateralIdLiteral, vaultAccountId);
-        const rewardPerToken = await this.getRewardsPoolRewardPerToken(rewardCurrencyIdLiteral);
-        const rewardTally = await this.getRewardsPoolRewardTally(
-            rewardCurrencyIdLiteral,
-            vaultCollateralIdLiteral,
-            vaultAccountId
-        );
+        const stake = await this.getRewardsPoolStake(vaultCollateral, vaultAccountId);
+        const rewardPerToken = await this.getRewardsPoolRewardPerToken(rewardCurrency);
+        const rewardTally = await this.getRewardsPoolRewardTally(rewardCurrency, vaultCollateral, vaultAccountId);
         const rawLazyDistribution = computeLazyDistribution(stake, rewardPerToken, rewardTally);
-        return newMonetaryAmount(
-            rawLazyDistribution,
-            currencyIdLiteralToMonetaryCurrency(this.api, rewardCurrencyIdLiteral)
-        );
+        return newMonetaryAmount(rawLazyDistribution, rewardCurrency);
     }
 
-    async getRewardsPoolStake(vaultCollateralIdLiteral: CollateralIdLiteral, vaultAccountId: AccountId): Promise<Big> {
-        const collateralCurrency = currencyIdToMonetaryCurrency(
-            newCurrencyId(this.api, vaultCollateralIdLiteral)
-        ) as CollateralCurrency;
+    async getRewardsPoolStake(vaultCollateral: CollateralCurrencyExt, vaultAccountId: AccountId): Promise<Big> {
+        const collateralCurrency = await currencyIdToMonetaryCurrency(
+            this.assetRegistry,
+            newCurrencyId(this.api, vaultCollateral)
+        );
         const vaultId = newVaultId(this.api, vaultAccountId.toString(), collateralCurrency, this.wrappedCurrency);
         return decodeFixedPointType(await this.api.query.vaultRewards.stake(vaultId));
     }
 
     async getRewardsPoolRewardTally(
-        rewardCurrencyIdLiteral: CurrencyIdLiteral,
-        vaultCollateralIdLiteral: CollateralIdLiteral,
+        rewardCurrency: Currency,
+        vaultCollateral: CollateralCurrencyExt,
         vaultAccountId: AccountId
     ): Promise<Big> {
-        const rewardCurrencyId = newCurrencyId(this.api, rewardCurrencyIdLiteral);
-        currencyIdToMonetaryCurrency(newCurrencyId(this.api, rewardCurrencyIdLiteral)) as CollateralCurrency;
-        const collateralCurrency = currencyIdToMonetaryCurrency(
-            newCurrencyId(this.api, vaultCollateralIdLiteral)
-        ) as CollateralCurrency;
+        const rewardCurrencyId = newCurrencyId(this.api, rewardCurrency);
+        const collateralCurrency = await currencyIdToMonetaryCurrency(
+            this.assetRegistry,
+            newCurrencyId(this.api, vaultCollateral)
+        );
         const vaultId = newVaultId(this.api, vaultAccountId.toString(), collateralCurrency, this.wrappedCurrency);
         return decodeFixedPointType(await this.api.query.vaultRewards.rewardTally(rewardCurrencyId, vaultId));
     }
 
-    async getRewardsPoolRewardPerToken(currencyId: CurrencyIdLiteral): Promise<Big> {
+    async getRewardsPoolRewardPerToken(currency: Currency): Promise<Big> {
         return decodeFixedPointType(
-            await this.api.query.vaultRewards.rewardPerToken(newCurrencyId(this.api, currencyId))
+            await this.api.query.vaultRewards.rewardPerToken(newCurrencyId(this.api, currency))
         );
     }
 
-    async getRewardPerBlock(governanceCurrency: GovernanceIdLiteral): Promise<MonetaryAmount<GovernanceCurrency>> {
+    async getRewardPerBlock(governanceCurrency: GovernanceCurrency): Promise<MonetaryAmount<GovernanceCurrency>> {
         const rawRewardPerBlock = await this.api.query.vaultAnnuity.rewardPerBlock();
-        return newMonetaryAmount(
-            rawRewardPerBlock.toString(),
-            currencyIdLiteralToMonetaryCurrency(this.api, governanceCurrency)
-        );
+        return newMonetaryAmount(rawRewardPerBlock.toString(), governanceCurrency);
     }
 }

--- a/src/parachain/vaults.ts
+++ b/src/parachain/vaults.ts
@@ -38,7 +38,7 @@ import {
 } from "../types";
 import { RewardsAPI } from "./rewards";
 import { BalanceWrapper, UnsignedFixedPoint } from "../interfaces";
-import { AssetRegistryAPI, SystemAPI } from ".";
+import { AssetRegistryAPI, SystemAPI } from "./index";
 
 /**
  * @category BTC Bridge

--- a/src/parachain/vaults.ts
+++ b/src/parachain/vaults.ts
@@ -21,6 +21,7 @@ import {
     newVaultId,
     newVaultCurrencyPair,
     addHexPrefix,
+    currencyIdToMonetaryCurrency,
 } from "../utils";
 import { TokensAPI } from "./tokens";
 import { OracleAPI } from "./oracle";
@@ -28,25 +29,16 @@ import { FeeAPI } from "./fee";
 import { TransactionAPI } from "./transaction";
 import { ElectrsAPI } from "../external";
 import {
-    tickerToCurrencyIdLiteral,
     VaultExt,
     SystemVaultExt,
     VaultStatusExt,
-    currencyIdToMonetaryCurrency,
-    CollateralCurrency,
+    CollateralCurrencyExt,
     WrappedCurrency,
-    CurrencyIdLiteral,
-    WrappedIdLiteral,
-    CollateralIdLiteral,
-    currencyIdToLiteral,
-    tickerToMonetaryCurrency,
-    currencyIdLiteralToMonetaryCurrency,
-    GovernanceIdLiteral,
     GovernanceCurrency,
 } from "../types";
 import { RewardsAPI } from "./rewards";
 import { BalanceWrapper, UnsignedFixedPoint } from "../interfaces";
-import { SystemAPI } from ".";
+import { AssetRegistryAPI, SystemAPI } from ".";
 
 /**
  * @category BTC Bridge
@@ -60,17 +52,17 @@ export interface VaultsAPI {
      * Get a vault by account ID and collateral currency.
      * Does not reject if the vault does not exist, but returns null instead.
      * @param vaultAccountId The ID of the vault to fetch
-     * @param collateralCurrencyIdLiteral Collateral used by vault
+     * @param collateralCurrency Collateral used by vault
      * @returns A vault object, or null if no vault with the given ID and currency pair exists
      */
-    getOrNull(vaultAccountId: AccountId, collateralCurrencyIdLiteral: CurrencyIdLiteral): Promise<VaultExt | null>;
+    getOrNull(vaultAccountId: AccountId, collateralCurrency: CollateralCurrencyExt): Promise<VaultExt | null>;
     /**
      * Get a vault by account ID and collateral currency. Rejects if no vault exists.
      * @param vaultAccountId The ID of the vault to fetch
-     * @param collateralCurrencyIdLiteral Collateral used by vault
+     * @param collateralCurrency Collateral used by vault
      * @returns A vault object, rejects if no vault with the given ID and currency pair exists
      */
-    get(vaultAccountId: AccountId, collateralCurrencyIdLiteral: CurrencyIdLiteral): Promise<VaultExt>;
+    get(vaultAccountId: AccountId, collateralCurrency: CollateralCurrencyExt): Promise<VaultExt>;
     /**
      * Get the collateralization of a single vault measured by dividing the value of issued (wrapped) tokens
      * by the value of total locked collateral.
@@ -79,7 +71,7 @@ export interface VaultsAPI {
      * If no tokens have been issued, the `collateralFunds / issuedFunds` ratio divides by zero,
      * which means collateralization is infinite.
      * @param vaultAccountId the vault account id
-     * @param collateralCurrencyIdLiteral Collateral used by vault
+     * @param collateralCurrency Collateral used by vault
      * @param newCollateral use this instead of the vault's actual collateral
      * @param onlyIssued optional, defaults to `false`. Specifies whether the collateralization
      * should only include the issued tokens, leaving out unsettled ("to-be-issued") tokens
@@ -87,8 +79,8 @@ export interface VaultsAPI {
      */
     getVaultCollateralization(
         vaultAccountId: AccountId,
-        collateralCurrencyIdLiteral: CollateralIdLiteral,
-        newCollateral?: MonetaryAmount<CollateralCurrency>,
+        collateralCurrency: CollateralCurrencyExt,
+        newCollateral?: MonetaryAmount<CollateralCurrencyExt>,
         onlyIssued?: boolean
     ): Promise<Big | undefined>;
     // /**
@@ -104,28 +96,28 @@ export interface VaultsAPI {
      * current SecureCollateralThreshold with the current exchange rate
      *
      * @param vaultAccountId The vault account ID
-     * @param collateralCurrency The currency specification, a `Monetary.js` object
+     * @param collateralCurrency The currency specification, a `Monetary.js` object or `ForeignAsset`
      * @returns The required collateral the vault needs to deposit to stay
      * above the threshold limit
      */
     getRequiredCollateralForVault(
         vaultAccountId: AccountId,
-        collateralCurrency: CollateralCurrency
-    ): Promise<MonetaryAmount<CollateralCurrency>>;
+        collateralCurrency: CollateralCurrencyExt
+    ): Promise<MonetaryAmount<CollateralCurrencyExt>>;
     /**
      * Get the minimum secured collateral amount required to activate a vault
-     * @param collateralCurrency The currency specification, a `Monetary.js` object
+     * @param collateralCurrency The currency specification, a `Monetary.js` object or `ForeignAsset`
      * @returns the collateral value as a percentage string
      */
-    getMinimumCollateral(collateralCurrency: CollateralCurrency): Promise<Big>;
+    getMinimumCollateral(collateralCurrency: CollateralCurrencyExt): Promise<Big>;
     /**
      * @param vaultAccountId The vault account ID
-     * @param collateralCurrency The currency specification, a `Monetary.js` object
+     * @param collateralCurrency The currency specification, a `Monetary.js` object or `ForeignAsset
      * @returns The amount of wrapped tokens issued by the given vault
      */
     getIssuedAmount(
         vaultAccountId: AccountId,
-        collateralCurrency: CurrencyIdLiteral
+        collateralCurrency: CollateralCurrencyExt
     ): Promise<MonetaryAmount<WrappedCurrency>>;
     /**
      * @returns The total amount of wrapped tokens issued by the vaults
@@ -140,7 +132,7 @@ export interface VaultsAPI {
      * @param collateral Amount of collateral to calculate issuable capacity for
      * @returns Issuable amount by the vault, given the collateral amount
      */
-    calculateCapacity(collateral: MonetaryAmount<CollateralCurrency>): Promise<MonetaryAmount<WrappedCurrency>>;
+    calculateCapacity(collateral: MonetaryAmount<CollateralCurrencyExt>): Promise<MonetaryAmount<WrappedCurrency>>;
     /**
      * @param amount Wrapped tokens amount to issue
      * @returns A vault that has sufficient collateral to issue the given amount
@@ -176,19 +168,19 @@ export interface VaultsAPI {
      * If a Vault’s collateral rate
      * drops below this, automatic liquidation (forced Redeem) is triggered.
      */
-    getLiquidationCollateralThreshold(collateralCurrency: CollateralCurrency): Promise<Big>;
+    getLiquidationCollateralThreshold(collateralCurrency: CollateralCurrencyExt): Promise<Big>;
     /**
      * @param collateralCurrency
      * @returns The collateral rate at which users receive
      * a premium allocated from the Vault’s collateral, when performing a redeem with this Vault.
      */
-    getPremiumRedeemThreshold(collateralCurrency: CollateralCurrency): Promise<Big>;
+    getPremiumRedeemThreshold(collateralCurrency: CollateralCurrencyExt): Promise<Big>;
     /**
      * @param collateralCurrency
      * @returns The over-collateralization rate for collateral locked
      * by Vaults, necessary for issuing wrapped tokens
      */
-    getSecureCollateralThreshold(collateralCurrency: CollateralCurrency): Promise<Big>;
+    getSecureCollateralThreshold(collateralCurrency: CollateralCurrencyExt): Promise<Big>;
     /**
      * Get the total APY for a vault based on the income in wrapped and collateral tokens
      * divided by the locked collateral.
@@ -196,11 +188,11 @@ export interface VaultsAPI {
      * @note this does not account for interest compounding
      *
      * @param vaultAccountId The vault account ID
-     * @param collateralCurrency The currency specification, a `Monetary.js` object
+     * @param collateralCurrency The currency specification, a `Monetary.js` object or `ForeignAsset`
      * @param governanceCurrency The governance currency we're using for block rewards
      * @returns the APY as a percentage string
      */
-    getAPY(vaultAccountId: AccountId, collateralCurrency: CurrencyIdLiteral): Promise<Big>;
+    getAPY(vaultAccountId: AccountId, collateralCurrency: CollateralCurrencyExt): Promise<Big>;
     /**
      * Gets the estimated APY for just the block rewards (in governance tokens).
      * @param vaultAccountId: the vault account ID
@@ -212,8 +204,8 @@ export interface VaultsAPI {
     getBlockRewardAPY(
         vaultAccountId: AccountId,
         nominatorId: AccountId,
-        collateralCurrency: CollateralIdLiteral,
-        governanceCurrency: GovernanceIdLiteral
+        collateralCurrency: CollateralCurrencyExt,
+        governanceCurrency: GovernanceCurrency
     ): Promise<Big>;
     /**
      * @returns Fee that a Vault has to pay, as a percentage, if it fails to execute
@@ -225,39 +217,39 @@ export interface VaultsAPI {
     /**
      * @param amount The amount of collateral to withdraw
      */
-    withdrawCollateral(amount: MonetaryAmount<CollateralCurrency>): Promise<void>;
+    withdrawCollateral(amount: MonetaryAmount<CollateralCurrencyExt>): Promise<void>;
     /**
      * @param amount The amount of extra collateral to lock
      */
-    depositCollateral(amount: MonetaryAmount<CollateralCurrency>): Promise<void>;
+    depositCollateral(amount: MonetaryAmount<CollateralCurrencyExt>): Promise<void>;
     /**
      * @param collateralCurrency
      * @returns A vault object representing the liquidation vault
      */
-    getLiquidationVault(collateralCurrency: CollateralCurrency): Promise<SystemVaultExt>;
+    getLiquidationVault(collateralCurrency: CollateralCurrencyExt): Promise<SystemVaultExt>;
     /**
      * @param vaultAccountId The vault account ID
-     * @param collateralCurrency The currency specification, a `Monetary.js` object
+     * @param collateralCurrency The currency specification, a `Monetary.js` object or `ForeignAsset`
      * @returns The collateral of a vault, taking slashes into account.
      */
     getCollateral(
         vaultId: AccountId,
-        collateralCurrencyIdLiteral: CurrencyIdLiteral
-    ): Promise<MonetaryAmount<CollateralCurrency>>;
+        collateralCurrency: CollateralCurrencyExt
+    ): Promise<MonetaryAmount<CollateralCurrencyExt>>;
     /**
-     * @param collateralCurrency The collateral currency specification, a `Monetary.js` object
+     * @param collateralCurrency The collateral currency specification, a `Monetary.js` object or `ForeignAsset`
      * @returns The maximum collateral a vault can accept as nomination, as a ratio of its own collateral
      */
-    getMaxNominationRatio(collateralCurrency: CollateralCurrency): Promise<Big>;
+    getMaxNominationRatio(collateralCurrency: CollateralCurrencyExt): Promise<Big>;
     /**
      * @param vaultAccountId The vault account ID
-     * @param collateralCurrency The currency specification, a `Monetary.js` object
+     * @param collateralCurrency The currency specification, a `Monetary.js` object or `ForeignAsset`
      * @returns Staking capacity, as a collateral currency (e.g. DOT)
      */
     getStakingCapacity(
         vaultAccountId: AccountId,
-        collateralCurrency: CurrencyIdLiteral
-    ): Promise<MonetaryAmount<CollateralCurrency>>;
+        collateralCurrency: CollateralCurrencyExt
+    ): Promise<MonetaryAmount<CollateralCurrencyExt>>;
     /**
      * @param vaultId Vault ID object
      * @param nonce Nonce of the staking pool
@@ -266,7 +258,7 @@ export interface VaultsAPI {
     computeBackingCollateral(
         vaultId: InterbtcPrimitivesVaultId,
         nonce?: number
-    ): Promise<MonetaryAmount<CollateralCurrency>>;
+    ): Promise<MonetaryAmount<CollateralCurrencyExt>>;
     /**
      * A relayer may report Vault misbehavior by providing a fraud proof
      * (malicious Bitcoin transaction and transaction inclusion proof).
@@ -285,39 +277,39 @@ export interface VaultsAPI {
      * Compute the total reward, including the staking (local) pool and the rewards (global) pool
      * @param vaultAccountId The vault ID whose reward pool to check
      * @param nominatorId The account ID of the staking pool nominator
-     * @param vaultCollateralIdLiteral Collateral used by the vault. This is the currency used as
+     * @param vaultCollateral Collateral used by the vault. This is the currency used as
      * stake in the `staking` and `rewards` pools.
-     * @param rewardCurrencyIdLiteral The reward currency, e.g. kBTC, KINT, interBTC, INTR
+     * @param rewardCurrency The reward currency, e.g. kBTC, KINT, interBTC, INTR
      * @returns A Monetary.js amount object, representing the total reward in the given currency
      */
     computeReward(
         vaultAccountId: AccountId,
         nominatorId: AccountId,
-        collateralCurrencyId: CollateralIdLiteral,
-        rewardCurrencyIdLiteral: CurrencyIdLiteral,
+        collateralCurrency: CollateralCurrencyExt,
+        rewardCurrency: Currency,
         nonce?: number
     ): Promise<MonetaryAmount<Currency>>;
     /**
      * @param vaultAccountId The vault ID whose reward pool to check
-     * @param vaultCollateralIdLiteral Collateral used by the vault
-     * @param rewardCurrencyIdLiteral The fee reward currency
+     * @param vaultCollateral Collateral used by the vault
+     * @param rewardCurrency The fee reward currency
      * @returns The total reward collected by the vault
      */
     getWrappedReward(
         vaultAccountId: AccountId,
-        vaultCollateralIdLiteral: CollateralIdLiteral,
-        rewardCurrencyIdLiteral: WrappedIdLiteral
+        vaultCollateral: CollateralCurrencyExt,
+        rewardCurrency: WrappedCurrency
     ): Promise<MonetaryAmount<WrappedCurrency>>;
     /**
      * @param vaultAccountId The vault ID whose reward pool to check
-     * @param vaultCollateralIdLiteral Collateral used by the vault
-     * @param governanceCurrencyIdLiteral The fee reward currency
+     * @param vaultCollateral Collateral used by the vault
+     * @param governanceCurrency The fee reward currency
      * @returns The total reward collected by the vault
      */
     getGovernanceReward(
         vaultAccountId: AccountId,
-        vaultCollateralIdLiteral: CollateralIdLiteral,
-        governanceCurrencyIdLiteral: GovernanceIdLiteral
+        vaultCollateral: CollateralCurrencyExt,
+        governanceCurrency: GovernanceCurrency
     ): Promise<MonetaryAmount<GovernanceCurrency>>;
     /**
      * Enables or disables issue requests for given vault
@@ -339,20 +331,17 @@ export class DefaultVaultsAPI implements VaultsAPI {
         private feeAPI: FeeAPI,
         private rewardsAPI: RewardsAPI,
         private systemAPI: SystemAPI,
-        private transactionAPI: TransactionAPI
+        private transactionAPI: TransactionAPI,
+        private assetRegistryAPI: AssetRegistryAPI
     ) {}
 
     getWrappedCurrency(): WrappedCurrency {
         return this.wrappedCurrency;
     }
 
-    async register(amount: MonetaryAmount<CollateralCurrency>, publicKey: string): Promise<void> {
+    async register(amount: MonetaryAmount<CollateralCurrencyExt>, publicKey: string): Promise<void> {
         const amountAtomicUnit = this.api.createType("Balance", amount.toString(true));
-        const currencyPair = newVaultCurrencyPair(
-            this.api,
-            tickerToMonetaryCurrency(this.api, amount.currency.ticker) as CollateralCurrency,
-            this.wrappedCurrency
-        );
+        const currencyPair = newVaultCurrencyPair(this.api, amount.currency, this.wrappedCurrency);
         await Promise.all([
             this.transactionAPI.sendLogged(
                 this.api.tx.vaultRegistry.registerPublicKey(publicKey),
@@ -367,24 +356,16 @@ export class DefaultVaultsAPI implements VaultsAPI {
         ]);
     }
 
-    async withdrawCollateral(amount: MonetaryAmount<CollateralCurrency>): Promise<void> {
+    async withdrawCollateral(amount: MonetaryAmount<CollateralCurrencyExt>): Promise<void> {
         const amountAtomicUnit = this.api.createType("Balance", amount.toString(true));
-        const currencyPair = newVaultCurrencyPair(
-            this.api,
-            tickerToMonetaryCurrency(this.api, amount.currency.ticker) as CollateralCurrency,
-            this.wrappedCurrency
-        );
+        const currencyPair = newVaultCurrencyPair(this.api, amount.currency, this.wrappedCurrency);
         const tx = this.api.tx.vaultRegistry.withdrawCollateral(currencyPair, amountAtomicUnit);
         await this.transactionAPI.sendLogged(tx, this.api.events.vaultRegistry.WithdrawCollateral, true);
     }
 
-    async depositCollateral(amount: MonetaryAmount<CollateralCurrency>): Promise<void> {
+    async depositCollateral(amount: MonetaryAmount<CollateralCurrencyExt>): Promise<void> {
         const amountAsPlanck = this.api.createType("Balance", amount.toString(true));
-        const currencyPair = newVaultCurrencyPair(
-            this.api,
-            tickerToMonetaryCurrency(this.api, amount.currency.ticker) as CollateralCurrency,
-            this.wrappedCurrency
-        );
+        const currencyPair = newVaultCurrencyPair(this.api, amount.currency, this.wrappedCurrency);
         const tx = this.api.tx.vaultRegistry.depositCollateral(currencyPair, amountAsPlanck);
         await this.transactionAPI.sendLogged(tx, this.api.events.vaultRegistry.DepositCollateral, true);
     }
@@ -400,15 +381,8 @@ export class DefaultVaultsAPI implements VaultsAPI {
         );
     }
 
-    async getOrNull(
-        vaultAccountId: AccountId,
-        collateralCurrencyIdLiteral: CollateralIdLiteral
-    ): Promise<VaultExt | null> {
+    async getOrNull(vaultAccountId: AccountId, collateralCurrency: CollateralCurrencyExt): Promise<VaultExt | null> {
         try {
-            const collateralCurrency = currencyIdLiteralToMonetaryCurrency(
-                this.api,
-                collateralCurrencyIdLiteral
-            ) as CollateralCurrency;
             const vaultId = newVaultId(this.api, vaultAccountId.toString(), collateralCurrency, this.wrappedCurrency);
             const vault = await this.api.query.vaultRegistry.vaults<Option<VaultRegistryVault>>(vaultId);
             if (!vault.isSome) {
@@ -420,14 +394,12 @@ export class DefaultVaultsAPI implements VaultsAPI {
         }
     }
 
-    async get(vaultAccountId: AccountId, collateralCurrencyIdLiteral: CollateralIdLiteral): Promise<VaultExt> {
-        const vault = await this.getOrNull(vaultAccountId, collateralCurrencyIdLiteral);
+    async get(vaultAccountId: AccountId, collateralCurrency: CollateralCurrencyExt): Promise<VaultExt> {
+        const vault = await this.getOrNull(vaultAccountId, collateralCurrency);
 
         if (vault === null) {
             return Promise.reject(
-                new Error(
-                    `Vault does not exist for id '${vaultAccountId}' and collateral '${collateralCurrencyIdLiteral}'`
-                )
+                new Error(`Vault does not exist for id '${vaultAccountId}' and collateral '${collateralCurrency.name}'`)
             );
         }
         return vault;
@@ -435,26 +407,22 @@ export class DefaultVaultsAPI implements VaultsAPI {
 
     async getCollateral(
         vaultAccountId: AccountId,
-        collateralCurrencyIdLiteral: CollateralIdLiteral
-    ): Promise<MonetaryAmount<CollateralCurrency>> {
-        const collateralCurrency = currencyIdLiteralToMonetaryCurrency(
-            this.api,
-            collateralCurrencyIdLiteral
-        ) as CollateralCurrency;
+        collateralCurrency: CollateralCurrencyExt
+    ): Promise<MonetaryAmount<CollateralCurrencyExt>> {
         return this.rewardsAPI.computeCollateralInStakingPool(
             newVaultId(this.api, vaultAccountId.toString(), collateralCurrency, this.wrappedCurrency),
             vaultAccountId
         );
     }
 
-    async getMinimumCollateral(collateralCurrency: CollateralCurrency): Promise<Big> {
-        const collateralCurrencyId = newCurrencyId(this.api, tickerToCurrencyIdLiteral(collateralCurrency.ticker));
+    async getMinimumCollateral(collateralCurrency: CollateralCurrencyExt): Promise<Big> {
+        const collateralCurrencyId = newCurrencyId(this.api, collateralCurrency);
         const minimumCollateral = await this.api.query.vaultRegistry.minimumCollateralVault(collateralCurrencyId);
 
         return decodeFixedPointType(minimumCollateral);
     }
 
-    async getMaxNominationRatio(collateralCurrency: CollateralCurrency): Promise<Big> {
+    async getMaxNominationRatio(collateralCurrency: CollateralCurrencyExt): Promise<Big> {
         const [premiumRedeemThreshold, secureCollateralThreshold] = await Promise.all([
             this.getPremiumRedeemThreshold(collateralCurrency),
             this.getSecureCollateralThreshold(collateralCurrency),
@@ -465,28 +433,26 @@ export class DefaultVaultsAPI implements VaultsAPI {
     async computeBackingCollateral(
         vaultId: InterbtcPrimitivesVaultId,
         nonce?: number
-    ): Promise<MonetaryAmount<CollateralCurrency>> {
-        const collateralCurrencyIdLiteral = currencyIdToLiteral(vaultId.currencies.collateral) as CollateralIdLiteral;
+    ): Promise<MonetaryAmount<CollateralCurrencyExt>> {
+        const collateralCurrency = await currencyIdToMonetaryCurrency(
+            this.assetRegistryAPI,
+            vaultId.currencies.collateral
+        );
         if (nonce === undefined) {
-            nonce = await this.rewardsAPI.getStakingPoolNonce(collateralCurrencyIdLiteral, vaultId.accountId);
+            nonce = await this.rewardsAPI.getStakingPoolNonce(collateralCurrency, vaultId.accountId);
         }
 
         const rawBackingCollateral = await this.api.query.vaultStaking.totalCurrentStake(nonce, vaultId);
-        const collateralCurrency = currencyIdToMonetaryCurrency(vaultId.currencies.collateral);
         return newMonetaryAmount(decodeFixedPointType(rawBackingCollateral), collateralCurrency);
     }
 
     async backingCollateralProportion(
         vaultAccountId: AccountId,
         nominatorId: AccountId,
-        collateralCurrencyIdLiteral: CollateralIdLiteral
+        collateralCurrency: CollateralCurrencyExt
     ): Promise<Big> {
-        const vault = await this.get(vaultAccountId, collateralCurrencyIdLiteral);
+        const vault = await this.get(vaultAccountId, collateralCurrency);
 
-        const collateralCurrency = currencyIdLiteralToMonetaryCurrency(
-            this.api,
-            collateralCurrencyIdLiteral
-        ) as CollateralCurrency;
         const nominatorCollateral = await this.rewardsAPI.computeCollateralInStakingPool(
             newVaultId(this.api, vaultAccountId.toString(), collateralCurrency, this.wrappedCurrency),
             nominatorId
@@ -509,8 +475,8 @@ export class DefaultVaultsAPI implements VaultsAPI {
     async getBlockRewardAPY(
         vaultAccountId: AccountId,
         nominatorId: AccountId,
-        collateralCurrency: CollateralIdLiteral,
-        governanceCurrency: GovernanceIdLiteral
+        collateralCurrency: CollateralCurrencyExt,
+        governanceCurrency: GovernanceCurrency
     ): Promise<Big> {
         const vault = await this.get(vaultAccountId, collateralCurrency);
         const [globalRewardPerBlock, globalStake, vaultStake, vaultRewardShare, lockedCollateral, minimumBlockPeriod] =
@@ -521,7 +487,7 @@ export class DefaultVaultsAPI implements VaultsAPI {
                 this.backingCollateralProportion(vaultAccountId, nominatorId, collateralCurrency),
                 (
                     await this.tokensAPI.balance(
-                        currencyIdToMonetaryCurrency(vault.id.currencies.collateral),
+                        await currencyIdToMonetaryCurrency(this.assetRegistryAPI, vault.id.currencies.collateral),
                         vaultAccountId
                     )
                 ).reserved,
@@ -545,20 +511,20 @@ export class DefaultVaultsAPI implements VaultsAPI {
     async computeReward(
         vaultAccountId: AccountId,
         nominatorId: AccountId,
-        collateralCurrencyId: CollateralIdLiteral,
-        rewardCurrencyIdLiteral: CurrencyIdLiteral,
+        collateralCurrency: CollateralCurrencyExt,
+        rewardCurrency: Currency,
         nonce?: number
     ): Promise<MonetaryAmount<Currency>> {
         const [totalGlobalReward, globalRewardShare] = await Promise.all([
-            this.rewardsAPI.computeRewardInRewardsPool(rewardCurrencyIdLiteral, collateralCurrencyId, vaultAccountId),
-            this.backingCollateralProportion(vaultAccountId, nominatorId, collateralCurrencyId),
+            this.rewardsAPI.computeRewardInRewardsPool(rewardCurrency, collateralCurrency, vaultAccountId),
+            this.backingCollateralProportion(vaultAccountId, nominatorId, collateralCurrency),
         ]);
         const ownGlobalReward = totalGlobalReward.mul(globalRewardShare);
         const localReward = await this.rewardsAPI.computeRewardInStakingPool(
             vaultAccountId,
             nominatorId,
-            collateralCurrencyId,
-            rewardCurrencyIdLiteral,
+            collateralCurrency,
+            rewardCurrency,
             nonce
         );
         return ownGlobalReward.add(localReward);
@@ -566,48 +532,41 @@ export class DefaultVaultsAPI implements VaultsAPI {
 
     async getWrappedReward(
         vaultAccountId: AccountId,
-        collateralCurrency: CollateralIdLiteral
+        collateralCurrency: CollateralCurrencyExt
     ): Promise<MonetaryAmount<WrappedCurrency>> {
-        return await this.computeReward(
-            vaultAccountId,
-            vaultAccountId,
-            collateralCurrency,
-            tickerToCurrencyIdLiteral(this.wrappedCurrency.ticker)
-        );
+        return await this.computeReward(vaultAccountId, vaultAccountId, collateralCurrency, this.wrappedCurrency);
     }
 
     async getGovernanceReward(
         vaultAccountId: AccountId,
-        vaultCollateralIdLiteral: CollateralIdLiteral,
-        governanceCurrencyIdLiteral: GovernanceIdLiteral
+        vaultCollateral: CollateralCurrencyExt,
+        governanceCurrency: GovernanceCurrency
     ): Promise<MonetaryAmount<GovernanceCurrency>> {
-        return await this.computeReward(
-            vaultAccountId,
-            vaultAccountId,
-            vaultCollateralIdLiteral,
-            governanceCurrencyIdLiteral
-        );
+        return await this.computeReward(vaultAccountId, vaultAccountId, vaultCollateral, governanceCurrency);
     }
 
     async getStakingCapacity(
         vaultAccountId: AccountId,
-        collateralCurrency: CollateralIdLiteral
-    ): Promise<MonetaryAmount<CollateralCurrency>> {
+        collateralCurrency: CollateralCurrencyExt
+    ): Promise<MonetaryAmount<CollateralCurrencyExt>> {
         const vault = await this.get(vaultAccountId, collateralCurrency);
         const [collateral, maxNominationRatio] = await Promise.all([
             this.getCollateral(vaultAccountId, collateralCurrency),
-            this.getMaxNominationRatio(currencyIdToMonetaryCurrency(vault.id.currencies.collateral)),
+            this.getMaxNominationRatio(
+                await currencyIdToMonetaryCurrency(this.assetRegistryAPI, vault.id.currencies.collateral)
+            ),
         ]);
         return collateral.mul(maxNominationRatio).sub(vault.backingCollateral);
     }
 
-    async getLiquidationVault(collateralCurrency: CollateralCurrency): Promise<SystemVaultExt> {
+    async getLiquidationVault(collateralCurrency: CollateralCurrencyExt): Promise<SystemVaultExt> {
         const vaultCurrencyPair = newVaultCurrencyPair(this.api, collateralCurrency, this.wrappedCurrency);
         const liquidationVault = await this.api.query.vaultRegistry.liquidationVault(vaultCurrencyPair);
         if (!liquidationVault.isSome) {
             return Promise.reject("System vault could not be fetched");
         }
-        return parseSystemVault(
+        return await parseSystemVault(
+            this.assetRegistryAPI,
             liquidationVault.value as VaultRegistrySystemVault,
             this.wrappedCurrency,
             collateralCurrency
@@ -621,7 +580,7 @@ export class DefaultVaultsAPI implements VaultsAPI {
     async isBelowPremiumThreshold(vaultId: InterbtcPrimitivesVaultId): Promise<boolean> {
         const [premiumRedeemThreshold, vaultCollateralization] = await Promise.all([
             this.getPremiumRedeemThreshold(
-                currencyIdToMonetaryCurrency(vaultId.currencies.collateral) as CollateralCurrency
+                await currencyIdToMonetaryCurrency(this.assetRegistryAPI, vaultId.currencies.collateral)
             ),
             this.getCollateralizationFromVault(vaultId),
         ]);
@@ -630,18 +589,12 @@ export class DefaultVaultsAPI implements VaultsAPI {
 
     async getVaultCollateralization(
         vaultAccountId: AccountId,
-        collateralCurrencyIdLiteral: CollateralIdLiteral,
-        newCollateral?: MonetaryAmount<CollateralCurrency>,
+        collateralCurrency: CollateralCurrencyExt,
+        newCollateral?: MonetaryAmount<CollateralCurrencyExt>,
         onlyIssued = false
     ): Promise<Big | undefined> {
         let collateralization = undefined;
-        const collateralCurrencyId = newCurrencyId(this.api, collateralCurrencyIdLiteral);
-        const vaultId = newVaultId(
-            this.api,
-            vaultAccountId.toString(),
-            currencyIdToMonetaryCurrency(collateralCurrencyId) as CollateralCurrency,
-            this.wrappedCurrency
-        );
+        const vaultId = newVaultId(this.api, vaultAccountId.toString(), collateralCurrency, this.wrappedCurrency);
         try {
             if (newCollateral) {
                 collateralization = await this.getCollateralizationFromVaultAndCollateral(
@@ -671,12 +624,12 @@ export class DefaultVaultsAPI implements VaultsAPI {
 
     async getCollateralizationFromVaultAndCollateral(
         vaultId: InterbtcPrimitivesVaultId,
-        newCollateral: MonetaryAmount<CollateralCurrency>,
+        newCollateral: MonetaryAmount<CollateralCurrencyExt>,
         onlyIssued: boolean
     ): Promise<Big> {
         const vault = await this.get(
             vaultId.accountId,
-            currencyIdToLiteral(vaultId.currencies.collateral) as CollateralIdLiteral
+            await currencyIdToMonetaryCurrency(this.assetRegistryAPI, vaultId.currencies.collateral)
         );
         const issuedTokens = await (onlyIssued ? Promise.resolve(vault.issuedTokens) : vault.getBackedTokens());
         if (issuedTokens.isZero()) {
@@ -693,17 +646,17 @@ export class DefaultVaultsAPI implements VaultsAPI {
 
     async getRequiredCollateralForVault(
         vaultAccountId: AccountId,
-        currency: CollateralCurrency
-    ): Promise<MonetaryAmount<CollateralCurrency>> {
-        const vault = await this.get(vaultAccountId, tickerToCurrencyIdLiteral(currency.ticker) as CollateralIdLiteral);
+        currency: CollateralCurrencyExt
+    ): Promise<MonetaryAmount<CollateralCurrencyExt>> {
+        const vault = await this.get(vaultAccountId, currency);
         const issuedTokens = vault.getBackedTokens();
         return await this.getRequiredCollateralForWrapped(issuedTokens, currency);
     }
 
     async getRequiredCollateralForWrapped(
         wrappedAmount: MonetaryAmount<WrappedCurrency>,
-        currency: CollateralCurrency
-    ): Promise<MonetaryAmount<CollateralCurrency>> {
+        currency: CollateralCurrencyExt
+    ): Promise<MonetaryAmount<CollateralCurrencyExt>> {
         const secureCollateralThreshold = await this.getSecureCollateralThreshold(currency);
         const requiredCollateralInWrappedCurrency = wrappedAmount.mul(secureCollateralThreshold);
         return await this.oracleAPI.convertWrappedToCurrency(requiredCollateralInWrappedCurrency, currency);
@@ -711,7 +664,7 @@ export class DefaultVaultsAPI implements VaultsAPI {
 
     async getIssuedAmount(
         vaultAccountId: AccountId,
-        collateralCurrency: CollateralIdLiteral
+        collateralCurrency: CollateralCurrencyExt
     ): Promise<MonetaryAmount<WrappedCurrency>> {
         const vault = await this.get(vaultAccountId, collateralCurrency);
         return vault.issuedTokens;
@@ -726,24 +679,35 @@ export class DefaultVaultsAPI implements VaultsAPI {
         // get [[wrapped, collateral], amount][] map
         const perCurrencyPairCollateralAmounts = await this.api.query.vaultRegistry.totalUserVaultCollateral.entries();
         // filter for wrapped === this.wrapped, as only one wrapped currency is handled at a time currently
-        const perWrappedCurrencyCollateralAmounts = perCurrencyPairCollateralAmounts.filter(
-            ([key, _val]) => currencyIdToMonetaryCurrency(key.args[0].wrapped).name === this.wrappedCurrency.name
-        );
+        const perWrappedCurrencyCollateralAmounts: typeof perCurrencyPairCollateralAmounts = [];
+        for (const [key, _val] of perCurrencyPairCollateralAmounts) {
+            const entryWrappedCurrency = await currencyIdToMonetaryCurrency(this.assetRegistryAPI, key.args[0].wrapped);
+            if (entryWrappedCurrency.name === this.wrappedCurrency.name) {
+                perWrappedCurrencyCollateralAmounts.push([key, _val]);
+            }
+        }
+
         // reduce from [[this.wrapped, collateral], amount][] pairs to [collateral, sumAmount][] map
-        const perCollateralCurrencyCollateralAmounts = perWrappedCurrencyCollateralAmounts.reduce(
-            (amounts, [key, amount]) => {
-                const collateralCurrency = currencyIdToMonetaryCurrency(key.args[0].collateral);
-                let collateralAmount = newMonetaryAmount(amount.toString(), collateralCurrency);
-                if (amounts.has(collateralCurrency)) {
+        const perCollateralCurrencyCollateralAmounts = new Map<
+            CollateralCurrencyExt,
+            MonetaryAmount<CollateralCurrencyExt>
+        >();
+        for (const [key, amount] of perWrappedCurrencyCollateralAmounts) {
+            const collateralCurrency = await currencyIdToMonetaryCurrency(
+                this.assetRegistryAPI,
+                key.args[0].collateral
+            );
+            let collateralAmount = newMonetaryAmount(amount.toString(), collateralCurrency);
+            if (perCollateralCurrencyCollateralAmounts.has(collateralCurrency)) {
+                collateralAmount = collateralAmount.add(
                     // .has() is true, hence non-null
                     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                    collateralAmount = collateralAmount.add(amounts.get(collateralCurrency)!);
-                }
-                amounts.set(collateralCurrency, collateralAmount);
-                return amounts;
-            },
-            new Map<CollateralCurrency, MonetaryAmount<CollateralCurrency>>()
-        );
+                    perCollateralCurrencyCollateralAmounts.get(collateralCurrency)!
+                );
+            }
+            perCollateralCurrencyCollateralAmounts.set(collateralCurrency, collateralAmount);
+        }
+
         // finally convert the CollateralAmount sums to issuable amounts and sum those to get the total
         const [perCollateralCurrencyIssuableAmounts, issuedAmountBtc] = await Promise.all([
             Promise.all(
@@ -757,11 +721,13 @@ export class DefaultVaultsAPI implements VaultsAPI {
         return totalIssuableAmount.sub(issuedAmountBtc);
     }
 
-    async calculateCapacity(collateral: MonetaryAmount<CollateralCurrency>): Promise<MonetaryAmount<WrappedCurrency>> {
+    async calculateCapacity(
+        collateral: MonetaryAmount<CollateralCurrencyExt>
+    ): Promise<MonetaryAmount<WrappedCurrency>> {
         try {
             const [exchangeRate, secureCollateralThreshold] = await Promise.all([
                 this.oracleAPI.getExchangeRate(collateral.currency),
-                this.getSecureCollateralThreshold(collateral.currency as unknown as CollateralCurrency),
+                this.getSecureCollateralThreshold(collateral.currency),
             ]);
             const unusedCollateral = collateral.div(secureCollateralThreshold);
             return exchangeRate.toBase(unusedCollateral);
@@ -870,7 +836,7 @@ export class DefaultVaultsAPI implements VaultsAPI {
         return theftReports.isEmpty;
     }
 
-    async getLiquidationCollateralThreshold(collateralCurrency: CollateralCurrency): Promise<Big> {
+    async getLiquidationCollateralThreshold(collateralCurrency: CollateralCurrencyExt): Promise<Big> {
         const vaultCurrencyPair = newVaultCurrencyPair(this.api, collateralCurrency, this.wrappedCurrency);
         const threshold = await this.api.query.vaultRegistry.liquidationCollateralThreshold(vaultCurrencyPair);
         if (!threshold.isSome) {
@@ -879,7 +845,7 @@ export class DefaultVaultsAPI implements VaultsAPI {
         return decodeFixedPointType(threshold.value as UnsignedFixedPoint);
     }
 
-    async getPremiumRedeemThreshold(collateralCurrency: CollateralCurrency): Promise<Big> {
+    async getPremiumRedeemThreshold(collateralCurrency: CollateralCurrencyExt): Promise<Big> {
         const vaultCurrencyPair = newVaultCurrencyPair(this.api, collateralCurrency, this.wrappedCurrency);
         const threshold = await this.api.query.vaultRegistry.premiumRedeemThreshold(vaultCurrencyPair);
         if (!threshold.isSome) {
@@ -888,28 +854,23 @@ export class DefaultVaultsAPI implements VaultsAPI {
         return decodeFixedPointType(threshold.value as UnsignedFixedPoint);
     }
 
-    async getSecureCollateralThreshold(collateralCurrency: CollateralCurrency): Promise<Big> {
+    async getSecureCollateralThreshold(collateralCurrency: CollateralCurrencyExt): Promise<Big> {
         const vaultCurrencyPair = newVaultCurrencyPair(this.api, collateralCurrency, this.wrappedCurrency);
         const threshold = await this.api.query.vaultRegistry.secureCollateralThreshold(vaultCurrencyPair);
         return decodeFixedPointType(threshold.value as UnsignedFixedPoint);
     }
 
-    async getAPY(vaultAccountId: AccountId, collateralCurrency: CollateralIdLiteral): Promise<Big> {
+    async getAPY(vaultAccountId: AccountId, collateralCurrency: CollateralCurrencyExt): Promise<Big> {
         const vault = await this.get(vaultAccountId, collateralCurrency);
         const [feesWrapped, lockedCollateral, blockRewardsAPY] = await Promise.all([
             await this.getWrappedReward(vaultAccountId, collateralCurrency),
             (
                 await this.tokensAPI.balance(
-                    currencyIdToMonetaryCurrency(vault.id.currencies.collateral),
+                    await currencyIdToMonetaryCurrency(this.assetRegistryAPI, vault.id.currencies.collateral),
                     vaultAccountId
                 )
             ).reserved,
-            this.getBlockRewardAPY(
-                vaultAccountId,
-                vaultAccountId,
-                collateralCurrency,
-                tickerToCurrencyIdLiteral(this.governanceCurrency.ticker) as GovernanceIdLiteral
-            ),
+            this.getBlockRewardAPY(vaultAccountId, vaultAccountId, collateralCurrency, this.governanceCurrency),
         ]);
         return (await this.feeAPI.calculateAPY(feesWrapped, lockedCollateral)).add(blockRewardsAPY);
     }
@@ -919,18 +880,11 @@ export class DefaultVaultsAPI implements VaultsAPI {
         return decodeFixedPointType(fee);
     }
 
-    private wrapCurrency(amount: MonetaryAmount<CollateralCurrency>): BalanceWrapper {
+    private wrapCurrency(amount: MonetaryAmount<CollateralCurrencyExt>): BalanceWrapper {
         return this.api.createType("BalanceWrapper", {
             amount: this.api.createType("u128", amount.toString(true)),
-            currencyId: newCurrencyId(this.api, tickerToCurrencyIdLiteral(amount.currency.ticker)),
+            currencyId: newCurrencyId(this.api, amount.currency),
         });
-    }
-
-    private unwrapCurrency(wrappedBalance: BalanceWrapper): MonetaryAmount<CollateralCurrency> {
-        return newMonetaryAmount(
-            wrappedBalance.amount.toString(),
-            currencyIdToMonetaryCurrency(wrappedBalance.currencyId)
-        );
     }
 
     private parseVaultStatus(status: VaultRegistryVaultStatus): VaultStatusExt {
@@ -946,7 +900,10 @@ export class DefaultVaultsAPI implements VaultsAPI {
     }
 
     async parseVault(vault: VaultRegistryVault, network: Network): Promise<VaultExt> {
-        const collateralCurrency = currencyIdToMonetaryCurrency(vault.id.currencies.collateral);
+        const collateralCurrency = await currencyIdToMonetaryCurrency(
+            this.assetRegistryAPI,
+            vault.id.currencies.collateral
+        );
         const replaceCollateral = newMonetaryAmount(vault.replaceCollateral.toString(), collateralCurrency);
         const liquidatedCollateral = newMonetaryAmount(vault.liquidatedCollateral.toString(), collateralCurrency);
         const backingCollateral = await this.computeBackingCollateral(vault.id);
@@ -954,6 +911,7 @@ export class DefaultVaultsAPI implements VaultsAPI {
             this.api,
             this.oracleAPI,
             this.systemAPI,
+            this.assetRegistryAPI,
             parseWallet(vault.wallet, network),
             backingCollateral,
             vault.id,

--- a/src/types/oracleTypes.ts
+++ b/src/types/oracleTypes.ts
@@ -1,6 +1,7 @@
-import { Bitcoin, Currency, ExchangeRate, Polkadot } from "@interlay/monetary-js";
+import { Bitcoin, ExchangeRate, Polkadot } from "@interlay/monetary-js";
+import { CurrencyExt } from "./currency";
 
-export interface OracleStatus<B extends Currency, C extends Currency> {
+export interface OracleStatus<B extends CurrencyExt, C extends CurrencyExt> {
     id: string;
     source: string;
     feed: string;

--- a/src/types/requestTypes.ts
+++ b/src/types/requestTypes.ts
@@ -1,6 +1,6 @@
-import { Bitcoin, MonetaryAmount } from "@interlay/monetary-js";
+import { Bitcoin, Currency, MonetaryAmount } from "@interlay/monetary-js";
 import { AccountId } from "@polkadot/types/interfaces";
-import { CollateralCurrency, WrappedCurrency } from "../types";
+import { CollateralCurrencyExt, WrappedCurrency } from "../types";
 import { InterbtcPrimitivesVaultId, InterbtcPrimitivesReplaceReplaceRequestStatus } from "@polkadot/types/lookup";
 
 export interface Issue {
@@ -8,7 +8,7 @@ export interface Issue {
     wrappedAmount: MonetaryAmount<WrappedCurrency>;
     userParachainAddress: string;
     bridgeFee: MonetaryAmount<WrappedCurrency>;
-    griefingCollateral: MonetaryAmount<CollateralCurrency>;
+    griefingCollateral: MonetaryAmount<Currency>;
     vaultWalletPubkey: string;
     creationBlock: number;
     creationTimestamp?: number;
@@ -47,7 +47,7 @@ export interface Redeem {
     id: string;
     userParachainAddress: string;
     amountBTC: MonetaryAmount<WrappedCurrency>;
-    collateralPremium: MonetaryAmount<CollateralCurrency>;
+    collateralPremium: MonetaryAmount<CollateralCurrencyExt>;
     bridgeFee: MonetaryAmount<WrappedCurrency>;
     btcTransferFee: MonetaryAmount<Bitcoin>;
     creationTimestamp?: number;
@@ -89,8 +89,8 @@ export interface ReplaceRequestExt {
     newVault: InterbtcPrimitivesVaultId;
     oldVault: InterbtcPrimitivesVaultId;
     amount: MonetaryAmount<WrappedCurrency>;
-    griefingCollateral: MonetaryAmount<CollateralCurrency>;
-    collateral: MonetaryAmount<CollateralCurrency>;
+    griefingCollateral: MonetaryAmount<Currency>;
+    collateral: MonetaryAmount<CollateralCurrencyExt>;
     acceptTime: number;
     period: number;
     btcHeight: number;

--- a/src/utils/currency.ts
+++ b/src/utils/currency.ts
@@ -20,7 +20,7 @@ import { ApiPromise } from "@polkadot/api";
 import { FeeEstimationType } from "../types/oracleTypes";
 import { newCurrencyId } from "./encoding";
 import { InterbtcPrimitivesCurrencyId, InterbtcPrimitivesTokenSymbol } from "../interfaces";
-import { AssetRegistryAPI } from "..";
+import { AssetRegistryAPI } from "../parachain/asset-registry";
 
 // set maximum exponents
 Big.PE = 21;

--- a/src/utils/currency.ts
+++ b/src/utils/currency.ts
@@ -4,7 +4,9 @@ import {
     Bitcoin,
     Currency,
     ExchangeRate,
+    InterBtc,
     Interlay,
+    KBtc,
     Kintsugi,
     Kusama,
     MonetaryAmount,
@@ -13,10 +15,12 @@ import {
     VoteKintsugi,
 } from "@interlay/monetary-js";
 import { InterbtcPrimitivesOracleKey } from "@polkadot/types/lookup";
-import { tickerToCurrencyIdLiteral, GovernanceCurrency, CollateralCurrency } from "../types/currency";
+import { GovernanceCurrency, CurrencyExt, ForeignAsset, CollateralCurrencyExt } from "../types/currency";
 import { ApiPromise } from "@polkadot/api";
 import { FeeEstimationType } from "../types/oracleTypes";
 import { newCurrencyId } from "./encoding";
+import { InterbtcPrimitivesCurrencyId, InterbtcPrimitivesTokenSymbol } from "../interfaces";
+import { AssetRegistryAPI } from "..";
 
 // set maximum exponents
 Big.PE = 21;
@@ -50,9 +54,9 @@ export function atomicToBaseAmount(atomicAmount: BigSource, currency: Currency):
     return new Big(atomicAmount).div(new Big(10).pow(currency.decimals));
 }
 
-export function newMonetaryAmount(amount: BigSource, currency: Currency, base = false): MonetaryAmount<Currency> {
+export function newMonetaryAmount(amount: BigSource, currency: CurrencyExt, base = false): MonetaryAmount<CurrencyExt> {
     const finalAmount = base ? new Big(amount) : atomicToBaseAmount(amount, currency);
-    return new MonetaryAmount<Currency>(currency, finalAmount);
+    return new MonetaryAmount<CurrencyExt>(currency, finalAmount);
 }
 
 export function newCollateralBTCExchangeRate(
@@ -72,9 +76,9 @@ export function createInclusionOracleKey(api: ApiPromise, type: FeeEstimationTyp
 
 export function createExchangeRateOracleKey(
     api: ApiPromise,
-    collateralCurrency: Currency
+    collateralCurrency: CurrencyExt
 ): InterbtcPrimitivesOracleKey {
-    const currencyId = newCurrencyId(api, tickerToCurrencyIdLiteral(collateralCurrency.ticker));
+    const currencyId = newCurrencyId(api, collateralCurrency);
     return api.createType("InterbtcPrimitivesOracleKey", { ExchangeRate: currencyId });
 }
 
@@ -89,9 +93,10 @@ export function toVoting(governanceCurrency: GovernanceCurrency): Currency {
     }
 }
 
+// TODO: update to also return foreign assets?
 export function getCorrespondingCollateralCurrencies(
     governanceCurrency: GovernanceCurrency
-): Array<CollateralCurrency> {
+): Array<CollateralCurrencyExt> {
     switch (governanceCurrency.ticker) {
         case "KINT":
             return [Kusama, Kintsugi];
@@ -100,4 +105,60 @@ export function getCorrespondingCollateralCurrencies(
         default:
             throw new Error("Provided currency is not a governance currency");
     }
+}
+
+export function isForeignAsset(currencyExt: CurrencyExt): currencyExt is ForeignAsset {
+    // disable rule, use of any is deliberate for run time check
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return (currencyExt as any).id !== undefined;
+}
+
+export function isCurrency(currencyExt: CurrencyExt): currencyExt is Currency {
+    return !isForeignAsset(currencyExt);
+}
+
+export function isCurrencyEqual(currency: CurrencyExt, otherCurrency: CurrencyExt): boolean {
+    if (isForeignAsset(currency) && isForeignAsset(otherCurrency)) {
+        return currency.id === otherCurrency.id;
+    } else if (isCurrency(currency) && isCurrency(otherCurrency)) {
+        return currency.ticker === otherCurrency.ticker;
+    }
+
+    return false;
+}
+
+export async function currencyIdToMonetaryCurrency(
+    assetRegistryApi: AssetRegistryAPI,
+    currencyId: InterbtcPrimitivesCurrencyId
+): Promise<CurrencyExt> {
+    if (currencyId.isToken) {
+        return tokenSymbolToCurrency(currencyId.asToken);
+    } else if (currencyId.isForeignAsset) {
+        const foreignAssetId = currencyId.asForeignAsset;
+        return assetRegistryApi.getForeignAsset(foreignAssetId);
+    }
+
+    throw new Error(`No handling implemented for currencyId type of ${currencyId.type}`);
+}
+
+/**
+ * A method that will only try to find a hard-coded currencies.
+ * Only for use when we are certain the currency is not a foreign asset.
+ * @param tokenSymbol the InterbtcPrimitivesTokenSymbol to look up
+ */
+export function tokenSymbolToCurrency(tokenSymbol: InterbtcPrimitivesTokenSymbol): Currency {
+    if (tokenSymbol.isIbtc) {
+        return InterBtc;
+    } else if (tokenSymbol.isDot) {
+        return Polkadot;
+    } else if (tokenSymbol.isKsm) {
+        return Kusama;
+    } else if (tokenSymbol.isKbtc) {
+        return KBtc;
+    } else if (tokenSymbol.isKint) {
+        return Kintsugi;
+    } else if (tokenSymbol.isIntr) {
+        return Interlay;
+    }
+    throw new Error(`No entry provided for token symbol of type '${tokenSymbol?.type}'`);
 }

--- a/src/utils/issueRedeem.ts
+++ b/src/utils/issueRedeem.ts
@@ -9,9 +9,9 @@ import { InterbtcPrimitivesVaultId } from "@polkadot/types/lookup";
 import { newAccountId } from "../utils";
 import { BitcoinCoreClient } from "./bitcoin-core-client";
 import { stripHexPrefix } from "../utils/encoding";
-import { currencyIdToLiteral, Issue, IssueStatus, Redeem, RedeemStatus, WrappedCurrency } from "../types";
+import { Issue, IssueStatus, Redeem, RedeemStatus, WrappedCurrency } from "../types";
 import { waitForBlockFinalization } from "./bitcoin";
-import { atomicToBaseAmount, newMonetaryAmount } from "./currency";
+import { atomicToBaseAmount, currencyIdToMonetaryCurrency, newMonetaryAmount } from "./currency";
 import { InterBtcApi } from "..";
 
 export const SLEEP_TIME_MS = 1000;
@@ -117,11 +117,13 @@ export async function issueSingle(
         const initialWrappedTokenBalance = (await interBtcApi.tokens.balance(amount.currency, requesterAccountId)).free;
         const blocksToMine = 3;
 
-        const collateralIdLiteral = vaultId ? currencyIdToLiteral(vaultId.currencies.collateral) : undefined;
+        const collateralCurrency = vaultId
+            ? await currencyIdToMonetaryCurrency(interBtcApi.assetRegistry, vaultId.currencies.collateral)
+            : undefined;
         const rawRequestResult = await interBtcApi.issue.request(
             amount,
             vaultId?.accountId,
-            collateralIdLiteral,
+            collateralCurrency,
             atomic
         );
         if (rawRequestResult.length !== 1) {

--- a/src/utils/issueRedeem.ts
+++ b/src/utils/issueRedeem.ts
@@ -12,7 +12,7 @@ import { stripHexPrefix } from "../utils/encoding";
 import { Issue, IssueStatus, Redeem, RedeemStatus, WrappedCurrency } from "../types";
 import { waitForBlockFinalization } from "./bitcoin";
 import { atomicToBaseAmount, currencyIdToMonetaryCurrency, newMonetaryAmount } from "./currency";
-import { InterBtcApi } from "..";
+import { InterBtcApi } from "../interbtc-api";
 
 export const SLEEP_TIME_MS = 1000;
 

--- a/src/utils/setup.ts
+++ b/src/utils/setup.ts
@@ -30,7 +30,7 @@ import {
 } from "../../test/config";
 import { CollateralCurrencyExt, CurrencyExt, WrappedCurrency } from "../types";
 import { newVaultId } from "./encoding";
-import { InterBtcApi, DefaultInterBtcApi, newMonetaryAmount, getCorrespondingCollateralCurrencies } from "..";
+import { InterBtcApi, DefaultInterBtcApi, newMonetaryAmount, getCorrespondingCollateralCurrencies } from "../";
 import { AddressOrPair } from "@polkadot/api/types";
 
 // Command line arguments of the initialization script

--- a/src/utils/setup.ts
+++ b/src/utils/setup.ts
@@ -1,5 +1,5 @@
 /* eslint @typescript-eslint/no-var-requires: "off" */
-import { ExchangeRate, Bitcoin, Currency, MonetaryAmount } from "@interlay/monetary-js";
+import { ExchangeRate, Bitcoin, MonetaryAmount } from "@interlay/monetary-js";
 import { Big } from "big.js";
 import BN from "bn.js";
 import { ApiPromise, Keyring } from "@polkadot/api";
@@ -28,7 +28,7 @@ import {
     USER_1_URI,
     VAULT_1_URI,
 } from "../../test/config";
-import { CollateralCurrency, WrappedCurrency } from "../types";
+import { CollateralCurrencyExt, CurrencyExt, WrappedCurrency } from "../types";
 import { newVaultId } from "./encoding";
 import { InterBtcApi, DefaultInterBtcApi, newMonetaryAmount, getCorrespondingCollateralCurrencies } from "..";
 import { AddressOrPair } from "@polkadot/api/types";
@@ -93,7 +93,7 @@ export interface InitializeRedeem {
 export interface InitializationParams {
     initialize?: boolean;
     setStableConfirmations?: true | ChainConfirmations;
-    setExchangeRate?: true | ExchangeRate<Bitcoin, CollateralCurrency>;
+    setExchangeRate?: true | ExchangeRate<Bitcoin, CollateralCurrencyExt>;
     btcTxFees?: true | Big;
     enableNomination?: boolean;
     issue?: true | InitializeIssue;
@@ -105,14 +105,14 @@ function getDefaultInitializationParams(
     keyring: Keyring,
     vaultAddress: string,
     wrappedCurrency: WrappedCurrency,
-    collateralCurrency: CollateralCurrency
+    collateralCurrency: CollateralCurrencyExt
 ): InitializationParams {
     return {
         setStableConfirmations: {
             bitcoinConfirmations: 0,
             parachainConfirmations: 0,
         },
-        setExchangeRate: new ExchangeRate<Bitcoin, CollateralCurrency>(
+        setExchangeRate: new ExchangeRate<Bitcoin, CollateralCurrencyExt>(
             Bitcoin,
             collateralCurrency,
             new Big("3855.23187")
@@ -158,7 +158,7 @@ export async function initializeStableConfirmations(
 }
 
 export async function initializeExchangeRate(
-    exchangeRateToSet: ExchangeRate<Bitcoin, Currency>,
+    exchangeRateToSet: ExchangeRate<Bitcoin, CurrencyExt>,
     oracleAPI: OracleAPI
 ): Promise<void> {
     console.log("Initializing the exchange rate...");
@@ -243,7 +243,10 @@ async function main(params: InitializationParams): Promise<void> {
     if (params.setExchangeRate !== undefined) {
         const exchangeRateToSet =
             params.setExchangeRate === true
-                ? (defaultInitializationParams.setExchangeRate as unknown as ExchangeRate<Bitcoin, CollateralCurrency>)
+                ? (defaultInitializationParams.setExchangeRate as unknown as ExchangeRate<
+                      Bitcoin,
+                      CollateralCurrencyExt
+                  >)
                 : params.setExchangeRate;
         await initializeExchangeRate(exchangeRateToSet, oracleAccountInterBtcApi.oracle);
     }

--- a/test/integration/parachain/staging/fee.test.ts
+++ b/test/integration/parachain/staging/fee.test.ts
@@ -6,7 +6,7 @@ import Big from "big.js";
 import { createSubstrateAPI } from "../../../../src/factory";
 import { ESPLORA_BASE_PATH, ORACLE_URI, PARACHAIN_ENDPOINT } from "../../../config";
 import {
-    CollateralCurrency,
+    CollateralCurrencyExt,
     DefaultInterBtcApi,
     getCorrespondingCollateralCurrencies,
     InterBtcApi,
@@ -19,7 +19,7 @@ import { callWithExchangeRate } from "../../../utils/helpers";
 describe("fee", () => {
     let api: ApiPromise;
     let oracleInterBtcAPI: InterBtcApi;
-    let collateralCurrencies: Array<CollateralCurrency>;
+    let collateralCurrencies: Array<CollateralCurrencyExt>;
     let wrappedCurrency: WrappedCurrency;
 
     before(async function () {

--- a/test/integration/parachain/staging/sequential/asset-registry.test.ts
+++ b/test/integration/parachain/staging/sequential/asset-registry.test.ts
@@ -10,7 +10,7 @@ import { StorageKey } from "@polkadot/types";
 import { AnyTuple } from "@polkadot/types/types";
 import { AssetId } from "@polkadot/types/interfaces/runtime";
 import { OrmlAssetRegistryAssetMetadata } from "@polkadot/types/lookup";
-import { waitForFinalizedEvent } from "../../../../utils/helpers";
+import { waitForIncludedEvent } from "../../../../utils/helpers";
 
 describe("AssetRegistry", () => {
     let api: ApiPromise;
@@ -51,7 +51,7 @@ describe("AssetRegistry", () => {
             await interBtcAPI.api.tx.sudo.sudo(deleteKeysInstruction).signAndSend(sudoAccount);
 
             // wait for finalized event
-            await waitForFinalizedEvent(interBtcAPI, api.events.sudo.Sudid);
+            await waitForIncludedEvent(interBtcAPI, api.events.sudo.Sudid);
         }
 
         return api.disconnect();
@@ -59,8 +59,8 @@ describe("AssetRegistry", () => {
 
     /**
      * This test checks that the returned metadata from the chain has all the fields we need to construct
-     * a `Currency<UnitList>` object.
-     * To see the fields required, take a look at {@link DefaultAssetRegistryAPI.metadataTupleToForeignAsset}.
+     * a `Currency` object.
+     * To see the fields required, take a look at {@link DefaultAssetRegistryAPI.metadataToCurrency}.
      *
      * Note: More detailed tests around the internal logic are in the unit tests.
      */
@@ -84,8 +84,7 @@ describe("AssetRegistry", () => {
             // need sudo to add new foreign asset
             await interBtcAPI.api.tx.sudo.sudo(callToRegister).signAndSend(sudoAccount);
 
-            // wait for finalized event
-            await waitForFinalizedEvent(interBtcAPI, api.events.assetRegistry.RegisteredAsset);
+            await waitForIncludedEvent(interBtcAPI, api.events.sudo.Sudid);
         }
 
         // get the metadata for the asset we just registered
@@ -122,5 +121,5 @@ describe("AssetRegistry", () => {
                 );
             }
         }
-    }).timeout(5 * 60000);
+    }).timeout(3 * 60000);
 });

--- a/test/integration/parachain/staging/sequential/asset-registry.test.ts
+++ b/test/integration/parachain/staging/sequential/asset-registry.test.ts
@@ -3,11 +3,17 @@ import { ApiPromise, Keyring } from "@polkadot/api";
 import { KeyringPair } from "@polkadot/keyring/types";
 import { createSubstrateAPI } from "../../../../../src/factory";
 import { ESPLORA_BASE_PATH, PARACHAIN_ENDPOINT, SUDO_URI } from "../../../../config";
-import { DefaultAssetRegistryAPI, DefaultInterBtcApi, getStorageKey, stripHexPrefix } from "../../../../../src";
+import {
+    DefaultAssetRegistryAPI,
+    DefaultInterBtcApi,
+    getStorageKey,
+    storageKeyToNthInner,
+    stripHexPrefix,
+} from "../../../../../src";
 
 import { StorageKey } from "@polkadot/types";
 import { AnyTuple } from "@polkadot/types/types";
-
+import { AssetId } from "@polkadot/types/interfaces/runtime";
 import { OrmlAssetRegistryAssetMetadata } from "@polkadot/types/lookup";
 import { waitForFinalizedEvent } from "../../../../utils/helpers";
 
@@ -31,14 +37,14 @@ describe("AssetRegistry", () => {
         // check which keys exist before the tests
         registeredKeysBefore = (await interBtcAPI.api.rpc.state.getKeys(assetRegistryMetadataHash)).toArray();
     });
-    
+
     after(async () => {
         // clean up keys created in tests if necessary
         const registeredKeysAfter = (await interBtcAPI.api.rpc.state.getKeys(assetRegistryMetadataHash)).toArray();
 
-        const previousKeyHashes = registeredKeysBefore.map(key => stripHexPrefix(key.toHex()));
+        const previousKeyHashes = registeredKeysBefore.map((key) => stripHexPrefix(key.toHex()));
         // need to use string comparison since the raw StorageKeys don't play nicely with .filter()
-        const newKeys = registeredKeysAfter.filter(key => {
+        const newKeys = registeredKeysAfter.filter((key) => {
             const newKeyHash = stripHexPrefix(key.toHex());
             return !previousKeyHashes.includes(newKeyHash);
         });
@@ -50,17 +56,16 @@ describe("AssetRegistry", () => {
 
             // wait for finalized event
             await waitForFinalizedEvent(interBtcAPI, api.events.sudo.Sudid);
-
         }
-        
+
         return api.disconnect();
     });
 
     /**
-     * This test checks that the returned metadata from the chain has all the fields we need to construct 
-     * a `Currency<UnitList>` object. 
-     * To see the fields required, take a look at {@link DefaultAssetRegistryAPI.metadataToCurrency}.
-     * 
+     * This test checks that the returned metadata from the chain has all the fields we need to construct
+     * a `Currency<UnitList>` object.
+     * To see the fields required, take a look at {@link DefaultAssetRegistryAPI.metadataTupleToForeignAsset}.
+     *
      * Note: More detailed tests around the internal logic are in the unit tests.
      */
     it("should get expected shape of AssetRegistry metadata", async () => {
@@ -71,28 +76,29 @@ describe("AssetRegistry", () => {
             // no existing foreign assets; register a new foreign asset for the test
             const nextAssetId = (await interBtcAPI.api.query.assetRegistry.lastAssetId()).toNumber() + 1;
 
-            const callToRegister = interBtcAPI.api.tx.assetRegistry.registerAsset({ 
-                decimals: 6,
-                name: "Test coin",
-                symbol: "TSC",
-            },
-            api.createType("u32", nextAssetId)
+            const callToRegister = interBtcAPI.api.tx.assetRegistry.registerAsset(
+                {
+                    decimals: 6,
+                    name: "Test coin",
+                    symbol: "TSC",
+                },
+                api.createType("u32", nextAssetId)
             );
 
             // need sudo to add new foreign asset
             await interBtcAPI.api.tx.sudo.sudo(callToRegister).signAndSend(sudoAccount);
-    
+
             // wait for finalized event
             await waitForFinalizedEvent(interBtcAPI, api.events.assetRegistry.RegisteredAsset);
         }
-        
+
         // get the metadata for the asset we just registered
         const assetRegistryAPI = new DefaultAssetRegistryAPI(api);
-        const foreignAssetEntries = (await assetRegistryAPI.getAssetRegistryEntries());
-        const metadataArray = DefaultAssetRegistryAPI.extractMetadataFromEntries(foreignAssetEntries);
-        
+        const foreignAssetEntries = await assetRegistryAPI.getAssetRegistryEntries();
+        const unwrappedMetadataTupleArray = DefaultAssetRegistryAPI.unwrapMetadataFromEntries(foreignAssetEntries);
+
         type OrmlARAMetadataKey = keyof OrmlAssetRegistryAssetMetadata;
-       
+
         // now check that we have the fields we absolutely need on the returned metadata
         // check {@link DefaultAssetRegistryAPI.metadataToCurrency} to see which fields are needed.
         const requiredFieldClassnames = new Map<OrmlARAMetadataKey, string>([
@@ -101,17 +107,15 @@ describe("AssetRegistry", () => {
             ["decimals" as OrmlARAMetadataKey, "u32"],
         ]);
 
-        for (const metadata of metadataArray) {
-            assert.isDefined(
-                metadata, 
-                "Expected metadata to be defined, but it is not."
-            );
+        for (const [storageKey, metadata] of unwrappedMetadataTupleArray) {
+            assert.isDefined(metadata, "Expected metadata to be defined, but it is not.");
+            assert.isDefined(storageKey, "Expected storage key to be defined, but it is not.");
+
+            const storageKeyValue = storageKeyToNthInner<AssetId>(storageKey);
+            assert.isDefined(storageKeyValue, "Expected storage key can be decoded but it cannot.");
 
             for (const [key, className] of requiredFieldClassnames) {
-                assert.isDefined(
-                    metadata[key],
-                    `Expected metadata to have field ${key.toString()}, but it does not.`
-                );
+                assert.isDefined(metadata[key], `Expected metadata to have field ${key.toString()}, but it does not.`);
 
                 // check type
                 assert.equal(

--- a/test/integration/parachain/staging/sequential/asset-registry.test.ts
+++ b/test/integration/parachain/staging/sequential/asset-registry.test.ts
@@ -3,13 +3,8 @@ import { ApiPromise, Keyring } from "@polkadot/api";
 import { KeyringPair } from "@polkadot/keyring/types";
 import { createSubstrateAPI } from "../../../../../src/factory";
 import { ESPLORA_BASE_PATH, PARACHAIN_ENDPOINT, SUDO_URI } from "../../../../config";
-import {
-    DefaultAssetRegistryAPI,
-    DefaultInterBtcApi,
-    getStorageKey,
-    storageKeyToNthInner,
-    stripHexPrefix,
-} from "../../../../../src";
+import { DefaultAssetRegistryAPI, DefaultInterBtcApi, storageKeyToNthInner, stripHexPrefix } from "../../../../../src";
+import { getStorageKey } from "../../../../../src/utils/storage";
 
 import { StorageKey } from "@polkadot/types";
 import { AnyTuple } from "@polkadot/types/types";
@@ -35,7 +30,8 @@ describe("AssetRegistry", () => {
 
         assetRegistryMetadataHash = getStorageKey("AssetRegistry", "Metadata");
         // check which keys exist before the tests
-        registeredKeysBefore = (await interBtcAPI.api.rpc.state.getKeys(assetRegistryMetadataHash)).toArray();
+        const keys = await interBtcAPI.api.rpc.state.getKeys(assetRegistryMetadataHash);
+        registeredKeysBefore = keys.toArray();
     });
 
     after(async () => {

--- a/test/integration/parachain/staging/sequential/escrow.test.ts
+++ b/test/integration/parachain/staging/sequential/escrow.test.ts
@@ -13,13 +13,8 @@ import {
     VAULT_TO_BAN_URI,
     VAULT_TO_LIQUIDATE_URI,
 } from "../../../../config";
-import {
-    DefaultInterBtcApi,
-    GovernanceCurrency,
-    newAccountId,
-    newMonetaryAmount,
-    setNumericStorage,
-} from "../../../../../src";
+import { DefaultInterBtcApi, GovernanceCurrency, newAccountId, newMonetaryAmount } from "../../../../../src";
+import { setNumericStorage } from "../../../../../src/utils/storage";
 import { sudo } from "../../../../utils/helpers";
 
 describe("escrow", () => {

--- a/test/integration/parachain/staging/sequential/oracle.test.ts
+++ b/test/integration/parachain/staging/sequential/oracle.test.ts
@@ -6,7 +6,7 @@ import { createSubstrateAPI } from "../../../../../src/factory";
 import { assert } from "../../../../chai";
 import { ESPLORA_BASE_PATH, ORACLE_URI, PARACHAIN_ENDPOINT } from "../../../../config";
 import {
-    CollateralCurrency,
+    CollateralCurrencyExt,
     DefaultInterBtcApi,
     getCorrespondingCollateralCurrencies,
     InterBtcApi,
@@ -16,7 +16,7 @@ import { getExchangeRateValueToSetForTesting } from "../../../../utils/helpers";
 describe("OracleAPI", () => {
     let api: ApiPromise;
     let interBtcAPI: InterBtcApi;
-    let collateralCurrencies: Array<CollateralCurrency>;
+    let collateralCurrencies: Array<CollateralCurrencyExt>;
     let oracleAccount: KeyringPair;
 
     before(async () => {

--- a/test/integration/parachain/staging/sequential/redeem.test.ts
+++ b/test/integration/parachain/staging/sequential/redeem.test.ts
@@ -2,7 +2,9 @@ import { ApiPromise, Keyring } from "@polkadot/api";
 import { KeyringPair } from "@polkadot/keyring/types";
 import { Hash } from "@polkadot/types/interfaces";
 import {
+    AssetRegistryAPI,
     currencyIdToMonetaryCurrency,
+    DefaultAssetRegistryAPI,
     DefaultInterBtcApi,
     InterBtcApi,
     InterbtcPrimitivesVaultId,
@@ -50,6 +52,7 @@ describe("redeem", () => {
     let wrappedCurrency: WrappedCurrency;
 
     let interBtcAPI: InterBtcApi;
+    let assetRegistry: AssetRegistryAPI;
 
     const fetchBtcTxIdFromOpReturn = async (redeemRequestId: string): Promise<string> => {
         const opreturnData = stripHexPrefix(redeemRequestId);
@@ -63,6 +66,7 @@ describe("redeem", () => {
         keyring = new Keyring({ type: "sr25519" });
         userAccount = keyring.addFromUri(USER_1_URI);
         interBtcAPI = new DefaultInterBtcApi(api, "regtest", userAccount, ESPLORA_BASE_PATH);
+        assetRegistry = new DefaultAssetRegistryAPI(api);
 
         const collateralCurrencies = getCorrespondingCollateralCurrencies(interBtcAPI.getGovernanceCurrency());
         wrappedCurrency = interBtcAPI.getWrappedCurrency();
@@ -196,7 +200,7 @@ describe("redeem", () => {
         // get BTC tx id
         const btcTxId = await fetchBtcTxIdFromOpReturn(redeemRequest.id);
 
-        const collateralCurrency = currencyIdToMonetaryCurrency(vault_1_id.currencies.collateral);
+        const collateralCurrency = await currencyIdToMonetaryCurrency(assetRegistry, vault_1_id.currencies.collateral);
         const vaultBitcoinCoreClient = new BitcoinCoreClient(
             BITCOIN_CORE_NETWORK,
             BITCOIN_CORE_HOST,

--- a/test/integration/parachain/staging/sequential/refund.test.ts
+++ b/test/integration/parachain/staging/sequential/refund.test.ts
@@ -2,7 +2,9 @@ import { ApiPromise, Keyring } from "@polkadot/api";
 import { KeyringPair } from "@polkadot/keyring/types";
 
 import {
+    AssetRegistryAPI,
     currencyIdToMonetaryCurrency,
+    DefaultAssetRegistryAPI,
     DefaultInterBtcApi,
     getCorrespondingCollateralCurrencies,
     InterBtcApi,
@@ -37,6 +39,7 @@ describe("refund", () => {
     let vault_3_ids: Array<InterbtcPrimitivesVaultId>;
     let wrappedCurrency: WrappedCurrency;
     let interBtcAPI: InterBtcApi;
+    let assetRegistry: AssetRegistryAPI;
 
     before(async function () {
         api = await createSubstrateAPI(PARACHAIN_ENDPOINT);
@@ -50,6 +53,7 @@ describe("refund", () => {
             BITCOIN_CORE_WALLET
         );
         userAccount = keyring.addFromUri(USER_1_URI);
+        assetRegistry = new DefaultAssetRegistryAPI(api);
         interBtcAPI = new DefaultInterBtcApi(api, "regtest", userAccount, ESPLORA_BASE_PATH);
         const collateralCurrencies = getCorrespondingCollateralCurrencies(interBtcAPI.getGovernanceCurrency());
         wrappedCurrency = interBtcAPI.getWrappedCurrency();
@@ -65,7 +69,8 @@ describe("refund", () => {
 
     it("should not generate a refund request", async () => {
         for (const vault_3_id of vault_3_ids) {
-            const currencyTicker = currencyIdToMonetaryCurrency(vault_3_id.currencies.collateral).ticker;
+            const currencyTicker = (await currencyIdToMonetaryCurrency(assetRegistry, vault_3_id.currencies.collateral))
+                .ticker;
             const issueResult = await issueSingle(
                 interBtcAPI,
                 bitcoinCoreClient,
@@ -90,7 +95,8 @@ describe("refund", () => {
             this.skip();
         }
         for (const vault_3_id of vault_3_ids) {
-            const currencyTicker = currencyIdToMonetaryCurrency(vault_3_id.currencies.collateral).ticker;
+            const currencyTicker = (await currencyIdToMonetaryCurrency(assetRegistry, vault_3_id.currencies.collateral))
+                .ticker;
             const issueResult = await issueSingle(
                 interBtcAPI,
                 bitcoinCoreClient,

--- a/test/integration/parachain/staging/sequential/replace.test.ts
+++ b/test/integration/parachain/staging/sequential/replace.test.ts
@@ -4,7 +4,6 @@ import {
     AssetRegistryAPI,
     DefaultAssetRegistryAPI,
     DefaultInterBtcApi,
-    DefaultTransactionAPI,
     getCorrespondingCollateralCurrencies,
     InterBtcApi,
     InterbtcPrimitivesVaultId,
@@ -30,6 +29,7 @@ import { assert, expect } from "../../../../chai";
 import { issueSingle } from "../../../../../src/utils/issueRedeem";
 import { currencyIdToMonetaryCurrency, newAccountId, newVaultId, WrappedCurrency } from "../../../../../src";
 import { MonetaryAmount } from "@interlay/monetary-js";
+import { waitForEvent } from "test/utils/helpers";
 
 describe("replace", () => {
     let api: ApiPromise;
@@ -99,7 +99,7 @@ describe("replace", () => {
                     vault_3_id.currencies.collateral
                 );
                 const [foundEvent] = await Promise.all([
-                    DefaultTransactionAPI.waitForEvent(api, api.events.replace.AcceptReplace, APPROX_TEN_BLOCKS_MS),
+                    waitForEvent(interBtcAPI, api.events.replace.AcceptReplace, false, APPROX_TEN_BLOCKS_MS),
                     interBtcAPI.replace.request(replaceAmount, collateralCurrency),
                 ]);
 

--- a/test/integration/parachain/staging/sequential/replace.test.ts
+++ b/test/integration/parachain/staging/sequential/replace.test.ts
@@ -29,7 +29,7 @@ import { assert, expect } from "../../../../chai";
 import { issueSingle } from "../../../../../src/utils/issueRedeem";
 import { currencyIdToMonetaryCurrency, newAccountId, newVaultId, WrappedCurrency } from "../../../../../src";
 import { MonetaryAmount } from "@interlay/monetary-js";
-import { waitForEvent } from "test/utils/helpers";
+import { waitForEvent } from "../../../../utils/helpers";
 
 describe("replace", () => {
     let api: ApiPromise;

--- a/test/integration/parachain/staging/sequential/replace.test.ts
+++ b/test/integration/parachain/staging/sequential/replace.test.ts
@@ -99,7 +99,7 @@ describe("replace", () => {
                     vault_3_id.currencies.collateral
                 );
                 const [foundEvent] = await Promise.all([
-                    waitForEvent(interBtcAPI, api.events.replace.AcceptReplace, false, APPROX_TEN_BLOCKS_MS),
+                    waitForEvent(interBtcAPI, api.events.replace.AcceptReplace, true, APPROX_TEN_BLOCKS_MS),
                     interBtcAPI.replace.request(replaceAmount, collateralCurrency),
                 ]);
 

--- a/test/integration/parachain/staging/sequential/vaults.test.ts
+++ b/test/integration/parachain/staging/sequential/vaults.test.ts
@@ -6,13 +6,12 @@ import {
     DefaultInterBtcApi,
     InterBtcApi,
     InterbtcPrimitivesVaultId,
-    WrappedIdLiteral,
     currencyIdToMonetaryCurrency,
-    CollateralCurrency,
-    tickerToCurrencyIdLiteral,
-    GovernanceIdLiteral,
+    CollateralCurrencyExt,
     VaultStatusExt,
     GovernanceCurrency,
+    AssetRegistryAPI,
+    DefaultAssetRegistryAPI,
 } from "../../../../../src/index";
 
 import { createSubstrateAPI } from "../../../../../src/factory";
@@ -33,14 +32,7 @@ import {
     VAULT_TO_BAN_URI,
     ESPLORA_BASE_PATH,
 } from "../../../../config";
-import {
-    BitcoinCoreClient,
-    newAccountId,
-    WrappedCurrency,
-    newVaultId,
-    currencyIdToLiteral,
-    CollateralIdLiteral,
-} from "../../../../../src";
+import { BitcoinCoreClient, newAccountId, WrappedCurrency, newVaultId } from "../../../../../src";
 import {
     encodeVaultId,
     getCorrespondingCollateralCurrencies,
@@ -63,15 +55,17 @@ describe("vaultsAPI", () => {
     let bitcoinCoreClient: BitcoinCoreClient;
 
     let wrappedCurrency: WrappedCurrency;
-    let collateralCurrencies: Array<CollateralCurrency>;
+    let collateralCurrencies: Array<CollateralCurrencyExt>;
     let governanceCurrency: GovernanceCurrency;
 
     let interBtcAPI: InterBtcApi;
+    let assetRegistry: AssetRegistryAPI;
 
     before(async () => {
         api = await createSubstrateAPI(PARACHAIN_ENDPOINT);
         const keyring = new Keyring({ type: "sr25519" });
         oracleAccount = keyring.addFromUri(ORACLE_URI);
+        assetRegistry = new DefaultAssetRegistryAPI(api);
         interBtcAPI = new DefaultInterBtcApi(api, "regtest", undefined, ESPLORA_BASE_PATH);
         wrappedCurrency = interBtcAPI.getWrappedCurrency();
         governanceCurrency = interBtcAPI.getGovernanceCurrency();
@@ -126,16 +120,16 @@ describe("vaultsAPI", () => {
 
     it("should get the required collateral for the vault", async () => {
         for (const vault_1_id of vault_1_ids) {
-            const collateralCurrency = currencyIdToMonetaryCurrency(vault_1_id.currencies.collateral);
+            const collateralCurrency = await currencyIdToMonetaryCurrency(
+                assetRegistry,
+                vault_1_id.currencies.collateral
+            );
             const requiredCollateralForVault = await interBtcAPI.vaults.getRequiredCollateralForVault(
                 vault_1_id.accountId,
                 collateralCurrency
             );
 
-            const vault = await interBtcAPI.vaults.get(
-                vault_1_id.accountId,
-                currencyIdToLiteral(vault_1_id.currencies.collateral)
-            );
+            const vault = await interBtcAPI.vaults.get(vault_1_id.accountId, collateralCurrency);
 
             // The numeric value of the required collateral should be greater than that of issued tokens.
             // e.g. we require `0.8096` KSM for `0.00014` kBTC
@@ -153,25 +147,23 @@ describe("vaultsAPI", () => {
     it("should deposit and withdraw collateral", async () => {
         const prevAccount = interBtcAPI.account;
         for (const vault_1_id of vault_1_ids) {
-            const collateralCurrency = currencyIdToMonetaryCurrency(
+            const collateralCurrency = await currencyIdToMonetaryCurrency(
+                assetRegistry,
                 vault_1_id.currencies.collateral
-            ) as CollateralCurrency;
+            );
             const currencyTicker = collateralCurrency.ticker;
 
             interBtcAPI.setAccount(vault_1);
             const amount = newMonetaryAmount(100, collateralCurrency, true);
-            const collateralCurrencyIdLiteral = tickerToCurrencyIdLiteral(
-                collateralCurrency.ticker
-            ) as CollateralIdLiteral;
 
             const collateralizationBeforeDeposit = await interBtcAPI.vaults.getVaultCollateralization(
                 newAccountId(api, vault_1.address),
-                collateralCurrencyIdLiteral
+                collateralCurrency
             );
             await interBtcAPI.vaults.depositCollateral(amount);
             const collateralizationAfterDeposit = await interBtcAPI.vaults.getVaultCollateralization(
                 newAccountId(api, vault_1.address),
-                collateralCurrencyIdLiteral
+                collateralCurrency
             );
             if (collateralizationBeforeDeposit === undefined || collateralizationAfterDeposit == undefined) {
                 assert.fail(
@@ -189,7 +181,7 @@ describe("vaultsAPI", () => {
             await interBtcAPI.vaults.withdrawCollateral(amount);
             const collateralizationAfterWithdrawal = await interBtcAPI.vaults.getVaultCollateralization(
                 newAccountId(api, vault_1.address),
-                collateralCurrencyIdLiteral
+                collateralCurrency
             );
             if (collateralizationAfterWithdrawal === undefined) {
                 assert.fail(`Collateralization is undefined for vault with collateral currency ${currencyTicker}`);
@@ -221,22 +213,20 @@ describe("vaultsAPI", () => {
         const issuableAmountModifier = 0.9 / vault_3_ids.length;
 
         for (const vault_3_id of vault_3_ids) {
-            const collateralCurrency = currencyIdToMonetaryCurrency(
+            const collateralCurrency = await currencyIdToMonetaryCurrency(
+                assetRegistry,
                 vault_3_id.currencies.collateral
-            ) as CollateralCurrency;
+            );
             const currencyTicker = collateralCurrency.ticker;
 
-            const collateralCurrencyIdLiteral = currencyIdToLiteral(
-                vault_3_id.currencies.collateral
-            ) as CollateralIdLiteral;
-            const vault = await interBtcAPI.vaults.get(vault_3_id.accountId, collateralCurrencyIdLiteral);
+            const vault = await interBtcAPI.vaults.get(vault_3_id.accountId, collateralCurrency);
             let issuableAmount = await vault.getIssuableTokens();
             issuableAmount = issuableAmount.mul(issuableAmountModifier);
             await issueSingle(interBtcAPI, bitcoinCoreClient, oracleAccount, issuableAmount, vault_3_id);
 
             const currentVaultCollateralization = await interBtcAPI.vaults.getVaultCollateralization(
                 newAccountId(api, vault_3.address),
-                collateralCurrencyIdLiteral
+                collateralCurrency
             );
             if (currentVaultCollateralization === undefined) {
                 throw new Error("Collateralization is undefined");
@@ -275,7 +265,9 @@ describe("vaultsAPI", () => {
             // locate the amount for the current vault
             let premiumRedeemAmount: MonetaryAmount<WrappedCurrency> | undefined = undefined;
             for (const [vaultId, amount] of premiumRedeemVaults) {
-                if (encodeVaultId(vaultId) === encodeVaultId(vault_3_id)) {
+                if (
+                    (await encodeVaultId(assetRegistry, vaultId)) === (await encodeVaultId(assetRegistry, vault_3_id))
+                ) {
                     premiumRedeemAmount = amount;
                     break;
                 }
@@ -364,17 +356,15 @@ describe("vaultsAPI", () => {
 
     it("should fail to get vault collateralization for vault with zero collateral", async () => {
         for (const vault_1_id of vault_1_ids) {
-            const collateralCurrency = currencyIdToMonetaryCurrency(
+            const collateralCurrency = await currencyIdToMonetaryCurrency(
+                assetRegistry,
                 vault_1_id.currencies.collateral
-            ) as CollateralCurrency;
+            );
             const currencyTicker = collateralCurrency.ticker;
 
             const vault1Id = newAccountId(api, vault_1.address);
-            const collateralCurrencyIdLiteral = tickerToCurrencyIdLiteral(
-                collateralCurrency.ticker
-            ) as CollateralIdLiteral;
             assert.isRejected(
-                interBtcAPI.vaults.getVaultCollateralization(vault1Id, collateralCurrencyIdLiteral),
+                interBtcAPI.vaults.getVaultCollateralization(vault1Id, collateralCurrency),
                 `Collateralization should not be available (${currencyTicker} vault)`
             );
         }
@@ -382,15 +372,13 @@ describe("vaultsAPI", () => {
 
     it("should get the issuable InterBtc for a vault", async () => {
         for (const vault_1_id of vault_1_ids) {
-            const collateralCurrency = currencyIdToMonetaryCurrency(
+            const collateralCurrency = await currencyIdToMonetaryCurrency(
+                assetRegistry,
                 vault_1_id.currencies.collateral
-            ) as CollateralCurrency;
+            );
             const currencyTicker = collateralCurrency.ticker;
 
-            const collateralCurrencyIdLiteral = currencyIdToLiteral(
-                vault_1_id.currencies.collateral
-            ) as CollateralIdLiteral;
-            const vault = await interBtcAPI.vaults.get(vault_1_id.accountId, collateralCurrencyIdLiteral);
+            const vault = await interBtcAPI.vaults.get(vault_1_id.accountId, collateralCurrency);
             const issuableTokens = await vault.getIssuableTokens();
             assert.isTrue(
                 issuableTokens.gt(newMonetaryAmount(0, wrappedCurrency)),
@@ -407,17 +395,19 @@ describe("vaultsAPI", () => {
     // TODO: revisit after next publish why intrReward is always zero
     it.skip("should getFees", async () => {
         for (const vault_1_id of vault_1_ids) {
-            const collateralCurrency = currencyIdToMonetaryCurrency(
+            const collateralCurrency = await currencyIdToMonetaryCurrency(
+                assetRegistry,
                 vault_1_id.currencies.collateral
-            ) as CollateralCurrency;
+            );
+            const wrappedCurrency = await currencyIdToMonetaryCurrency(assetRegistry, vault_1_id.currencies.wrapped);
             const currencyTicker = collateralCurrency.ticker;
 
             const vault1Id = newAccountId(api, vault_1.address);
 
             const feesWrapped = await interBtcAPI.vaults.getWrappedReward(
                 vault1Id,
-                currencyIdToLiteral(vault_1_id.currencies.collateral) as CollateralIdLiteral,
-                currencyIdToLiteral(vault_1_id.currencies.wrapped) as WrappedIdLiteral
+                collateralCurrency,
+                wrappedCurrency
             );
             assert.isTrue(
                 feesWrapped.gt(newMonetaryAmount(0, wrappedCurrency)),
@@ -426,8 +416,8 @@ describe("vaultsAPI", () => {
 
             const intrReward = await interBtcAPI.vaults.getGovernanceReward(
                 vault1Id,
-                currencyIdToLiteral(vault_1_id.currencies.collateral) as CollateralIdLiteral,
-                tickerToCurrencyIdLiteral(governanceCurrency.ticker) as GovernanceIdLiteral
+                collateralCurrency,
+                governanceCurrency
             );
             assert.isTrue(
                 intrReward.gt(newMonetaryAmount(0, governanceCurrency)),
@@ -438,15 +428,13 @@ describe("vaultsAPI", () => {
 
     it("should getAPY", async () => {
         for (const vault_1_id of vault_1_ids) {
-            const collateralCurrency = currencyIdToMonetaryCurrency(
+            const collateralCurrency = await currencyIdToMonetaryCurrency(
+                assetRegistry,
                 vault_1_id.currencies.collateral
-            ) as CollateralCurrency;
+            );
             const currencyTicker = collateralCurrency.ticker;
 
-            const apy = await interBtcAPI.vaults.getAPY(
-                newAccountId(api, vault_1.address),
-                currencyIdToLiteral(vault_1_id.currencies.collateral) as CollateralIdLiteral
-            );
+            const apy = await interBtcAPI.vaults.getAPY(newAccountId(api, vault_1.address), collateralCurrency);
             const apyBig = new Big(apy);
             const apyBenchmark = new Big("0");
             assert.isTrue(
@@ -469,9 +457,9 @@ describe("vaultsAPI", () => {
 
     it("should disable and enable issuing with vault", async () => {
         const assertVaultStatus = async (id: InterbtcPrimitivesVaultId, expectedStatus: VaultStatusExt) => {
-            const collateralCurrencyIdLiteral = currencyIdToLiteral(id.currencies.collateral);
-            const currencyTicker = currencyIdToMonetaryCurrency(id.currencies.collateral).ticker;
-            const { status } = await interBtcAPI.vaults.get(id.accountId, collateralCurrencyIdLiteral);
+            const collateralCurrency = await currencyIdToMonetaryCurrency(assetRegistry, id.currencies.collateral);
+            const currencyTicker = collateralCurrency.ticker;
+            const { status } = await interBtcAPI.vaults.get(id.accountId, collateralCurrency);
             const assertionMessage = `Vault with id ${id.toString()} (collateral: ${currencyTicker}) was expected to have 
                     status: ${vaultStatusToLabel(expectedStatus)}, but got status: ${vaultStatusToLabel(status)}`;
 

--- a/test/integration/parachain/staging/setup/initialize.test.ts
+++ b/test/integration/parachain/staging/setup/initialize.test.ts
@@ -1,7 +1,7 @@
 import { ApiPromise, Keyring } from "@polkadot/api";
 import { KeyringPair } from "@polkadot/keyring/types";
 import { AccountId } from "@polkadot/types/interfaces";
-import { Bitcoin, Currency, ExchangeRate, Kintsugi, Kusama, Polkadot } from "@interlay/monetary-js";
+import { Bitcoin, ExchangeRate, Kintsugi, Kusama, Polkadot } from "@interlay/monetary-js";
 import { assert } from "chai";
 import Big from "big.js";
 
@@ -10,12 +10,11 @@ import {
     createSubstrateAPI,
     VaultsAPI,
     newAccountId,
-    CurrencyIdLiteral,
     InterBtcApi,
     DefaultInterBtcApi,
     getCorrespondingCollateralCurrencies,
-    CollateralCurrency,
-    tickerToCurrencyIdLiteral,
+    CollateralCurrencyExt,
+    CurrencyExt,
 } from "../../../../../src";
 import {
     initializeVaultNomination,
@@ -58,13 +57,13 @@ describe("Initialize parachain state", () => {
     let vault_to_ban: KeyringPair;
     let vault_to_liquidate: KeyringPair;
 
-    let collateralCurrency: CollateralCurrency;
+    let collateralCurrency: CollateralCurrencyExt;
 
     function accountIdFromKeyring(keyPair: KeyringPair): AccountId {
         return newAccountId(api, keyPair.address);
     }
 
-    async function waitForRegister(api: VaultsAPI, accountId: AccountId, collateralCurrency: CurrencyIdLiteral) {
+    async function waitForRegister(api: VaultsAPI, accountId: AccountId, collateralCurrency: CollateralCurrencyExt) {
         for (;;) {
             try {
                 await api.get(accountId, collateralCurrency);
@@ -100,20 +99,19 @@ describe("Initialize parachain state", () => {
         sudoInterBtcAPI = new DefaultInterBtcApi(api, "regtest", sudoAccount, ESPLORA_BASE_PATH);
 
         collateralCurrency = getCorrespondingCollateralCurrencies(userInterBtcAPI.getGovernanceCurrency())[0];
-        const collateralCurrencyLiteral = tickerToCurrencyIdLiteral(collateralCurrency.ticker);
-        const vaultCollateralPairs: [KeyringPair, CurrencyIdLiteral][] = [
-            [vault_1, collateralCurrencyLiteral],
-            [vault_2, collateralCurrencyLiteral],
-            [vault_3, collateralCurrencyLiteral],
-            [vault_to_ban, collateralCurrencyLiteral],
-            [vault_to_liquidate, collateralCurrencyLiteral],
+        const vaultCollateralPairs: [KeyringPair, CollateralCurrencyExt][] = [
+            [vault_1, collateralCurrency],
+            [vault_2, collateralCurrency],
+            [vault_3, collateralCurrency],
+            [vault_to_ban, collateralCurrency],
+            [vault_to_liquidate, collateralCurrency],
         ];
         // wait for all vaults to register
         await Promise.all(
             vaultCollateralPairs
-                .map(([keyring, collateral]): [AccountId, CurrencyIdLiteral] => [
+                .map(([keyring, collateralCurrency]): [AccountId, CollateralCurrencyExt] => [
                     accountIdFromKeyring(keyring),
-                    collateral,
+                    collateralCurrency,
                 ])
                 .map(([accountId, collateral]) => waitForRegister(userInterBtcAPI.vaults, accountId, collateral))
         );
@@ -160,7 +158,7 @@ describe("Initialize parachain state", () => {
     });
 
     it("should set the exchange rate", async () => {
-        async function setCollateralExchangeRate(value: Big, currency: Currency) {
+        async function setCollateralExchangeRate(value: Big, currency: CurrencyExt) {
             const exchangeRate = new ExchangeRate<Bitcoin, typeof currency>(Bitcoin, currency, value);
             // result will be medianized
             await initializeExchangeRate(exchangeRate, sudoInterBtcAPI.oracle);

--- a/test/integration/parachain/staging/tokens.test.ts
+++ b/test/integration/parachain/staging/tokens.test.ts
@@ -1,6 +1,5 @@
 import { ApiPromise, Keyring } from "@polkadot/api";
 import { KeyringPair } from "@polkadot/keyring/types";
-import { Currency } from "@interlay/monetary-js";
 
 import { createSubstrateAPI } from "../../../../src/factory";
 import { assert } from "../../../chai";
@@ -8,7 +7,8 @@ import { USER_1_URI, USER_2_URI, PARACHAIN_ENDPOINT, ESPLORA_BASE_PATH } from ".
 import {
     ATOMIC_UNIT,
     ChainBalance,
-    CollateralCurrency,
+    CollateralCurrencyExt,
+    CurrencyExt,
     DefaultInterBtcApi,
     getCorrespondingCollateralCurrencies,
     InterBtcApi,
@@ -21,7 +21,7 @@ describe("TokensAPI", () => {
     let user1Account: KeyringPair;
     let user2Account: KeyringPair;
     let interBtcAPI: InterBtcApi;
-    let collateralCurrencies: Array<CollateralCurrency>;
+    let collateralCurrencies: Array<CollateralCurrencyExt>;
 
     before(async () => {
         api = await createSubstrateAPI(PARACHAIN_ENDPOINT);
@@ -42,7 +42,7 @@ describe("TokensAPI", () => {
         }
     });
 
-    async function testBalanceSubscription(currency: Currency): Promise<void> {
+    async function testBalanceSubscription(currency: CurrencyExt): Promise<void> {
         // Subscribe and receive two balance updates
         let updatedBalance = new ChainBalance(currency);
         let updatedAccount = "";

--- a/test/unit/mocks/vaultsTestMocks.ts
+++ b/test/unit/mocks/vaultsTestMocks.ts
@@ -1,17 +1,16 @@
 import Big, { BigSource } from "big.js";
 import sinon from "sinon";
 import {
-    CollateralCurrency,
+    CollateralCurrencyExt,
+    CurrencyExt,
     DefaultRewardsAPI,
     DefaultVaultsAPI,
     InterbtcPrimitivesVaultId,
     newMonetaryAmount,
     VaultExt,
 } from "../../../src";
-import * as allThingsCurrency from "../../../src/types/currency";
 import * as allThingsEncoding from "../../../src/utils/encoding";
 import { AccountId } from "@polkadot/types/interfaces";
-import { Currency } from "@interlay/monetary-js";
 
 export type NominatorVaultAccountIds = {
     nominatorId: AccountId;
@@ -34,7 +33,7 @@ export const prepareBackingCollateralProportionMocks = (
     stubbedRewardsApi: sinon.SinonStubbedInstance<DefaultRewardsAPI>,
     nominatorCollateralStakedAmount: Big,
     vaultBackingCollateralAmount: Big,
-    collateralCurrency: CollateralCurrency
+    collateralCurrency: CollateralCurrencyExt
 ): NominatorVaultAccountIds => {
     const nominatorId = createMockAccountId("mock nominator account id");
     const vaultId = createMockAccountId("mock vault account id");
@@ -48,7 +47,6 @@ export const prepareBackingCollateralProportionMocks = (
         nominatorCollateralStakedAmount,
         collateralCurrency
     );
-    mockCurrencyIdLiteralToMonetaryCurrency(sinon, collateralCurrency);
 
     return {
         nominatorId,
@@ -81,7 +79,7 @@ export const mockComputeCollateralInStakingPoolMethod = (
     sinon: sinon.SinonSandbox,
     stubbedRewardsApi: sinon.SinonStubbedInstance<DefaultRewardsAPI>,
     amount: BigSource,
-    currency: Currency
+    currency: CurrencyExt
 ): void => {
     // don't care what the inner method returns as we mock the outer one
     const tempId = <InterbtcPrimitivesVaultId>{};
@@ -97,7 +95,7 @@ export const mockComputeCollateralInStakingPoolMethod = (
  * @param collateralCurrency The collateral currency for the mocked backing collateral amount
  * @returns A mocked VaultExt instance with only backingCollateral property set
  */
-export const createMockVaultWithBacking = (amount: BigSource, collateralCurrency: CollateralCurrency): VaultExt => {
+export const createMockVaultWithBacking = (amount: BigSource, collateralCurrency: CollateralCurrencyExt): VaultExt => {
     // VaultExt-ish; only need .backingCollateral to be available for this test
     return {
         backingCollateral: newMonetaryAmount(amount, collateralCurrency as any),
@@ -117,16 +115,4 @@ export const mockVaultsApiGetMethod = (
 ): void => {
     // make VaultAPI.get() return a mocked vault
     sinon.stub(vaultsApi, "get").returns(Promise.resolve(vault));
-};
-
-/**
- * Mock the return value of Currency.idLiteralToMonetaryCurrency
- * @param sinon The sinon sandbox to use for mocking
- * @param currency The currency to return when calling currencyIdLiteralToMonetaryCurrency
- */
-export const mockCurrencyIdLiteralToMonetaryCurrency = (
-    sinon: sinon.SinonSandbox,
-    currency: CollateralCurrency
-): void => {
-    sinon.stub(allThingsCurrency, "currencyIdLiteralToMonetaryCurrency").returns(currency as any);
 };

--- a/test/unit/parachain/redeem.test.ts
+++ b/test/unit/parachain/redeem.test.ts
@@ -20,6 +20,7 @@ describe("DefaultRedeemAPI", () => {
             null as any,
             stubbedVaultsApi as VaultsAPI,
             null as any,
+            null as any,
             null as any
         );
     });

--- a/test/unit/parachain/vaults.test.ts
+++ b/test/unit/parachain/vaults.test.ts
@@ -1,14 +1,13 @@
 import { assert, expect } from "../../chai";
 import Big from "big.js";
 import sinon from "sinon";
-import { CollateralCurrency, CurrencyIdLiteral, DefaultRewardsAPI, DefaultVaultsAPI } from "../../../src";
+import { DefaultRewardsAPI, DefaultVaultsAPI } from "../../../src";
 import { Kusama } from "@interlay/monetary-js";
 import { prepareBackingCollateralProportionMocks } from "../mocks/vaultsTestMocks";
 
 describe("DefaultVaultsAPI", () => {
     let vaultsApi: DefaultVaultsAPI;
-    const testCollCcyId: CurrencyIdLiteral = CurrencyIdLiteral.KSM;
-    const testCollateralCurrency: CollateralCurrency = Kusama;
+    const testCollateralCurrency = Kusama;
 
     let stubbedRewardsApi: sinon.SinonStubbedInstance<DefaultRewardsAPI>;
 
@@ -26,6 +25,7 @@ describe("DefaultVaultsAPI", () => {
             null as any,
             null as any,
             stubbedRewardsApi,
+            null as any,
             null as any,
             null as any
         );
@@ -49,7 +49,11 @@ describe("DefaultVaultsAPI", () => {
             );
 
             // do the thing
-            const proportion = await vaultsApi.backingCollateralProportion(vaultId, nominatorId, testCollCcyId);
+            const proportion = await vaultsApi.backingCollateralProportion(
+                vaultId,
+                nominatorId,
+                testCollateralCurrency
+            );
 
             // check result
             const expectedProportion = new Big(0);
@@ -74,7 +78,11 @@ describe("DefaultVaultsAPI", () => {
             );
 
             // do & check
-            const proportionPromise = vaultsApi.backingCollateralProportion(vaultId, nominatorId, testCollCcyId);
+            const proportionPromise = vaultsApi.backingCollateralProportion(
+                vaultId,
+                nominatorId,
+                testCollateralCurrency
+            );
             expect(proportionPromise).to.be.rejectedWith(Error);
         });
 
@@ -92,7 +100,11 @@ describe("DefaultVaultsAPI", () => {
             );
 
             // do the thing
-            const proportion = await vaultsApi.backingCollateralProportion(vaultId, nominatorId, testCollCcyId);
+            const proportion = await vaultsApi.backingCollateralProportion(
+                vaultId,
+                nominatorId,
+                testCollateralCurrency
+            );
 
             // check result
             const expectedProportion = nominatorAmount.div(vaultAmount);

--- a/test/unit/utils/rewards.test.ts
+++ b/test/unit/utils/rewards.test.ts
@@ -1,7 +1,8 @@
 import { Currency, Kintsugi, KintsugiAmount } from "@interlay/monetary-js";
 import { assert } from "chai";
 import Big from "big.js";
-import { newMonetaryAmount, estimateReward, atomicToBaseAmount, ATOMIC_UNIT } from "../../../src";
+import { newMonetaryAmount, atomicToBaseAmount, ATOMIC_UNIT } from "../../../src";
+import { estimateReward } from "../../../src/utils/rewards";
 
 const WEEK_IN_BLOCKS = 54000;
 const MINIMUM_BLOCK_PERIOD = 6000; // 6s parachain constant

--- a/test/utils/helpers.ts
+++ b/test/utils/helpers.ts
@@ -1,5 +1,5 @@
 import { Transaction } from "@interlay/esplora-btc-api";
-import { Bitcoin, Currency, ExchangeRate } from "@interlay/monetary-js";
+import { Bitcoin, ExchangeRate } from "@interlay/monetary-js";
 import { Keyring } from "@polkadot/api";
 import { ApiTypes, AugmentedEvent } from "@polkadot/api/types";
 import { KeyringPair } from "@polkadot/keyring/types";
@@ -7,7 +7,14 @@ import { AnyTuple } from "@polkadot/types/types";
 import { mnemonicGenerate } from "@polkadot/util-crypto";
 import Big, { RoundingMode } from "big.js";
 import * as bitcoinjs from "bitcoinjs-lib";
-import { BitcoinCoreClient, InterBtcApi, OracleAPI, VaultStatusExt, DefaultTransactionAPI } from "../../src";
+import {
+    BitcoinCoreClient,
+    InterBtcApi,
+    OracleAPI,
+    VaultStatusExt,
+    DefaultTransactionAPI,
+    CurrencyExt,
+} from "../../src";
 import { SUDO_URI } from "../config";
 
 export const SLEEP_TIME_MS = 1000;
@@ -32,7 +39,7 @@ export async function wait_success<R>(call: () => Promise<R>): Promise<R> {
 
 export async function callWithExchangeRate(
     oracleAPI: OracleAPI,
-    exchangeRate: ExchangeRate<Bitcoin, Currency>,
+    exchangeRate: ExchangeRate<Bitcoin, CurrencyExt>,
     fn: () => Promise<void>
 ): Promise<void> {
     const initialExchangeRate = await oracleAPI.getExchangeRate(exchangeRate.counter);
@@ -122,7 +129,7 @@ export const vaultStatusToLabel = (status: VaultStatusExt): string => {
 // use the same exchange rate as the running oracles use
 // to avoid flaky tests due to updated prices from the oracle client(s)
 // note: currently the same for all collateral currencies - might change in future
-export const getExchangeRateValueToSetForTesting = (_collateralCurrency: Currency): Big => new Big("230.0");
+export const getExchangeRateValueToSetForTesting = (_collateralCurrency: CurrencyExt): Big => new Big("230.0");
 
 /**
  * Returns the vsize (virtual size) of the given transaction.


### PR DESCRIPTION
Add foreign assets to the model to be available in the same ways as monetary-js's Currency was before.

Changes:
1) Add `ForeignAsset`s as Currency, expanding the current Currency model.
Collateral currencies in particular can now be of type `CurrencyExt = Currency | ForeignAsset`, where `ForeignAsset = Currency & { id: number }`.
2) Remove `CurrencyIdLiteral`. Currency tickers are no longer the only primary identifier. ForeignAssets are identified by their respective on-chain ids (numeric) and may theoretically have clashing tickers.
3) Some minor refactoring/moving of methods to more suitable locations (eg. from `types/currency.ts` to `util/currency.ts`)

The best starting point to understand where all the changes come from is to start with what changed in `src/types/currency.ts` [here](https://github.com/interlay/interbtc-api/pull/436/files#diff-6cc7d53fe1f7dc8cf1e80369eb2ba258f456c8bee9aae4323086db7a7d968947)

Breaking changes to most APIs that previously took a `CurrencyIdLiteral`. Those will now take a `CurrencyExt` instead.
