### PR TITLE
Fix missed instance of issuable tokens call (no currency refactor version)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@interlay/interbtc-api",
-  "version": "1.13.5",
+  "version": "1.13.6",
   "description": "JavaScript library to interact with interBTC and kBTC",
   "main": "build/src/index.js",
   "typings": "build/src/index.d.ts",

--- a/src/parachain/vaults.ts
+++ b/src/parachain/vaults.ts
@@ -787,7 +787,10 @@ export class DefaultVaultsAPI implements VaultsAPI {
         ) as CollateralCurrency;
 
         const vaultId = newVaultId(this.api, vaultAccountId.toString(), collateralCurrency, this.getWrappedCurrency());
-        const balance = await this.api.rpc.vaultRegistry.getIssueableTokensFromVault(vaultId);
+        const balance = await this.api.rpc.vaultRegistry.getIssueableTokensFromVault({
+            account_id: vaultId.accountId,
+            currencies: vaultId.currencies,
+        });
         const amount = newMonetaryAmount(balance.amount.toString(), this.getWrappedCurrency());
         return amount;
     }

--- a/src/parachain/vaults.ts
+++ b/src/parachain/vaults.ts
@@ -835,25 +835,25 @@ export class DefaultVaultsAPI implements VaultsAPI {
     async getVaultsWithIssuableTokens(): Promise<
         Map<InterbtcPrimitivesVaultId, MonetaryAmount<Currency<BitcoinUnit>, BitcoinUnit>>
     > {
-        const map: Map<InterbtcPrimitivesVaultId, MonetaryAmount<WrappedCurrency, BitcoinUnit>> = new Map();
-        const [vaults, activeBlockNumber] = await Promise.all([
-            this.list(),
-            this.systemAPI.getCurrentActiveBlockNumber(),
-        ]);
-        const issuableTokens = await Promise.all(
-            vaults
-                .filter((vault) => {
-                    const bannedUntilBlockNumber = vault.bannedUntil || 0;
-                    return vault.status === VaultStatusExt.Active && bannedUntilBlockNumber < activeBlockNumber;
-                })
-                .map((vault) => {
-                    return new Promise<[MonetaryAmount<Currency<BitcoinUnit>, BitcoinUnit>, InterbtcPrimitivesVaultId]>(
-                        (resolve, _) => vault.getIssuableTokens().then((amount) => resolve([amount, vault.id]))
-                    );
-                })
+        const issuableVaults = await this.api.rpc.vaultRegistry.getVaultsWithIssuableTokens();
+        const wrappedCurrency = this.getWrappedCurrency();
+        const vaultIdsToAmountsMap = new Map(
+            issuableVaults.map(([vaultId, balanceWrapper]) => {
+                const amount = newMonetaryAmount(balanceWrapper.amount.toString(), this.getWrappedCurrency());
+                const collateralCcy = currencyIdToMonetaryCurrency(vaultId.currencies.collateral) as CollateralCurrency;
+
+                const ibtcPrimitivesVaultId = newVaultId(
+                    this.api,
+                    vaultId.account_id.toString(),
+                    collateralCcy,
+                    wrappedCurrency
+                );
+
+                return [ibtcPrimitivesVaultId, amount];
+            })
         );
-        issuableTokens.forEach(([amount, vaultId]) => map.set(vaultId, amount));
-        return map;
+
+        return vaultIdsToAmountsMap;
     }
 
     private isVaultEligibleForRedeem(vault: VaultExt<BitcoinUnit>, activeBlockNumber: number): boolean {

--- a/src/types/vault.ts
+++ b/src/types/vault.ts
@@ -58,7 +58,10 @@ export class VaultExt<WrappedUnit extends BitcoinUnit> {
     }
 
     async getIssuableTokens(): Promise<MonetaryAmount<Currency<WrappedUnit>, WrappedUnit>> {
-        const balance = await this.api.rpc.vaultRegistry.getIssueableTokensFromVault(this.id);
+        const balance = await this.api.rpc.vaultRegistry.getIssueableTokensFromVault({
+            account_id: this.id.accountId,
+            currencies: this.id.currencies,
+        });
         const wrapped = currencyIdToMonetaryCurrency(this.id.currencies.wrapped) as Currency<WrappedUnit>;
         return newMonetaryAmount(balance.amount.toString(), wrapped);
     }

--- a/src/types/vault.ts
+++ b/src/types/vault.ts
@@ -58,18 +58,9 @@ export class VaultExt<WrappedUnit extends BitcoinUnit> {
     }
 
     async getIssuableTokens(): Promise<MonetaryAmount<Currency<WrappedUnit>, WrappedUnit>> {
-        const isBanned = await this.isBanned();
-        if (isBanned) {
-            return newMonetaryAmount(0, currencyIdToMonetaryCurrency(this.id.currencies.wrapped));
-        }
-        const freeCollateral = await this.getFreeCollateral();
-        const secureCollateralThreshold = await this.getSecureCollateralThreshold();
-        const backableWrappedTokens = await this.oracleAPI.convertCollateralToWrapped(freeCollateral);
-        // Force type-assert here as the oracle API only uses wrapped Bitcoin
-        return backableWrappedTokens.div(secureCollateralThreshold) as unknown as MonetaryAmount<
-            Currency<WrappedUnit>,
-            WrappedUnit
-        >;
+        const balance = await this.api.rpc.vaultRegistry.getIssueableTokensFromVault(this.id);
+        const wrapped = currencyIdToMonetaryCurrency(this.id.currencies.wrapped) as Currency<WrappedUnit>;
+        return newMonetaryAmount(balance.amount.toString(), wrapped);
     }
 
     async isBanned(): Promise<boolean> {


### PR DESCRIPTION
Address missed methods in VaultsAPI and VaultExt to use rpc rather than calculate issuable tokens so the result works with custom collateral thresholds