### PR TITLE
Fix missed issuable tokens calls

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@interlay/interbtc-api",
-  "version": "1.16.1",
+  "version": "1.16.2",
   "description": "JavaScript library to interact with interBTC and kBTC",
   "main": "build/src/index.js",
   "typings": "build/src/index.d.ts",

--- a/src/interbtc-api.ts
+++ b/src/interbtc-api.ts
@@ -108,7 +108,6 @@ export class DefaultInterBtcApi implements InterBtcApi {
 
         this.vaults = new DefaultVaultsAPI(
             api,
-            btcNetwork,
             this.electrsAPI,
             wrappedCurrency,
             governanceCurrency,

--- a/src/parachain/vaults.ts
+++ b/src/parachain/vaults.ts
@@ -709,7 +709,10 @@ export class DefaultVaultsAPI implements VaultsAPI {
         collateralCurrency: CollateralCurrencyExt
     ): Promise<MonetaryAmount<WrappedCurrency>> {
         const vaultId = newVaultId(this.api, vaultAccountId.toString(), collateralCurrency, this.getWrappedCurrency());
-        const balance = await this.api.rpc.vaultRegistry.getIssueableTokensFromVault(vaultId);
+        const balance = await this.api.rpc.vaultRegistry.getIssueableTokensFromVault({
+            account_id: vaultId.accountId,
+            currencies: vaultId.currencies,
+        });
         const currency = await currencyIdToMonetaryCurrency(this.assetRegistryAPI, balance.currencyId);
         const amount = newMonetaryAmount(balance.amount.toString(), currency);
         return amount;

--- a/src/types/vault.ts
+++ b/src/types/vault.ts
@@ -59,18 +59,9 @@ export class VaultExt {
     }
 
     async getIssuableTokens(): Promise<MonetaryAmount<WrappedCurrency>> {
-        const isBanned = await this.isBanned();
-        if (isBanned) {
-            return newMonetaryAmount(
-                0,
-                await currencyIdToMonetaryCurrency(this.assetRegistryAPI, this.id.currencies.wrapped)
-            );
-        }
-        const freeCollateral = await this.getFreeCollateral();
-        const secureCollateralThreshold = await this.getSecureCollateralThreshold();
-        const backableWrappedTokens = await this.oracleAPI.convertCollateralToWrapped(freeCollateral);
-        // Force type-assert here as the oracle API only uses wrapped Bitcoin
-        return backableWrappedTokens.div(secureCollateralThreshold);
+        const balance = await this.api.rpc.vaultRegistry.getIssueableTokensFromVault(this.id);
+        const wrapped = await currencyIdToMonetaryCurrency(this.assetRegistryAPI, this.id.currencies.wrapped);
+        return newMonetaryAmount(balance.amount.toString(), wrapped);
     }
 
     async isBanned(): Promise<boolean> {

--- a/src/types/vault.ts
+++ b/src/types/vault.ts
@@ -59,7 +59,10 @@ export class VaultExt {
     }
 
     async getIssuableTokens(): Promise<MonetaryAmount<WrappedCurrency>> {
-        const balance = await this.api.rpc.vaultRegistry.getIssueableTokensFromVault(this.id);
+        const balance = await this.api.rpc.vaultRegistry.getIssueableTokensFromVault({
+            account_id: this.id.accountId,
+            currencies: this.id.currencies,
+        });
         const wrapped = await currencyIdToMonetaryCurrency(this.assetRegistryAPI, this.id.currencies.wrapped);
         return newMonetaryAmount(balance.amount.toString(), wrapped);
     }

--- a/test/unit/parachain/vaults.test.ts
+++ b/test/unit/parachain/vaults.test.ts
@@ -23,7 +23,6 @@ describe("DefaultVaultsAPI", () => {
             null as any,
             null as any,
             null as any,
-            null as any,
             stubbedRewardsApi,
             null as any,
             null as any,


### PR DESCRIPTION
Further fixes replacing calculations for issuable tokens with rpc calls which already take custom thresholds for vaults into account.

Bonus: Minor clean up of unused arguments / properties after previous removal of theft reporting