### PR TITLE
Feat: add api register new vault collateral

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@interlay/interbtc-api",
-  "version": "1.16.2",
+  "version": "1.16.3",
   "description": "JavaScript library to interact with interBTC and kBTC",
   "main": "build/src/index.js",
   "typings": "build/src/index.d.ts",

--- a/src/parachain/vaults.ts
+++ b/src/parachain/vaults.ts
@@ -333,7 +333,7 @@ export interface VaultsAPI {
      *
      * Rejects if with an Error if unable to register.
      *
-     * @param collateralAmount The collateral amount to register the vault with - includes the new collateral currency
+     * @param collateralAmount The collateral amount to register the vault with - in the new collateral currency
      */
     registerNewCollateralVault(collateralAmount: MonetaryAmount<CollateralCurrencyExt>): Promise<void>;
 }

--- a/src/parachain/vaults.ts
+++ b/src/parachain/vaults.ts
@@ -331,7 +331,7 @@ export interface VaultsAPI {
      * Registers a new vault for the current account ID with a new collateral amount.
      * Only applicable if the connected account ID already has a running vault with a different collateral currency.
      *
-     * Rejects if with an Error if unable to register.
+     * Rejects with an Error if unable to register.
      *
      * @param collateralAmount The collateral amount to register the vault with - in the new collateral currency
      */

--- a/test/unit/mocks/vaultsTestMocks.ts
+++ b/test/unit/mocks/vaultsTestMocks.ts
@@ -143,9 +143,9 @@ export const mockComputeCollateralInStakingPoolMethod = (
  */
 export const createMockVaultWithBacking = (amount: BigSource, collateralCurrency: CollateralCurrencyExt): VaultExt => {
     // VaultExt-ish; only need .backingCollateral to be available for this test
-    return {
-        backingCollateral: newMonetaryAmount(amount, collateralCurrency as any),
-    } as any;
+    return <VaultExt>{
+        backingCollateral: newMonetaryAmount(amount, collateralCurrency),
+    };
 };
 
 /**

--- a/test/unit/parachain/vaults.test.ts
+++ b/test/unit/parachain/vaults.test.ts
@@ -8,23 +8,20 @@ import {
     prepareRegisterNewCollateralVaultMocks,
     MOCKED_SEND_LOGGED_ERR_MSG,
 } from "../mocks/vaultsTestMocks";
-import { ApiPromise } from "@polkadot/api";
 
 describe("DefaultVaultsAPI", () => {
     let vaultsApi: DefaultVaultsAPI;
     const testCollateralCurrency = Kusama;
     const testWrappedCurrency = KBtc;
 
-    let stubbedApiPromise: sinon.SinonStubbedInstance<ApiPromise>;
     let stubbedRewardsApi: sinon.SinonStubbedInstance<DefaultRewardsAPI>;
     let stubbedTransactionApi: sinon.SinonStubbedInstance<DefaultTransactionAPI>;
 
     beforeEach(async () => {
-        stubbedApiPromise = sinon.createStubInstance(ApiPromise);
         stubbedRewardsApi = sinon.createStubInstance(DefaultRewardsAPI);
         stubbedTransactionApi = sinon.createStubInstance(DefaultTransactionAPI);
         vaultsApi = new DefaultVaultsAPI(
-            stubbedApiPromise as any,
+            null as any,
             null as any,
             testWrappedCurrency,
             null as any,

--- a/test/unit/parachain/vaults.test.ts
+++ b/test/unit/parachain/vaults.test.ts
@@ -1,31 +1,39 @@
 import { assert, expect } from "../../chai";
 import Big from "big.js";
 import sinon from "sinon";
-import { DefaultRewardsAPI, DefaultVaultsAPI } from "../../../src";
-import { Kusama } from "@interlay/monetary-js";
-import { prepareBackingCollateralProportionMocks } from "../mocks/vaultsTestMocks";
+import { DefaultRewardsAPI, DefaultTransactionAPI, DefaultVaultsAPI, newMonetaryAmount } from "../../../src";
+import { KBtc, Kusama } from "@interlay/monetary-js";
+import {
+    prepareBackingCollateralProportionMocks,
+    prepareRegisterNewCollateralVaultMocks,
+    MOCKED_SEND_LOGGED_ERR_MSG,
+} from "../mocks/vaultsTestMocks";
+import { ApiPromise } from "@polkadot/api";
 
 describe("DefaultVaultsAPI", () => {
     let vaultsApi: DefaultVaultsAPI;
     const testCollateralCurrency = Kusama;
+    const testWrappedCurrency = KBtc;
 
+    let stubbedApiPromise: sinon.SinonStubbedInstance<ApiPromise>;
     let stubbedRewardsApi: sinon.SinonStubbedInstance<DefaultRewardsAPI>;
+    let stubbedTransactionApi: sinon.SinonStubbedInstance<DefaultTransactionAPI>;
 
-    beforeEach(() => {
-        // only mock/stub what we really need
-        // add more if/when needed
+    beforeEach(async () => {
+        stubbedApiPromise = sinon.createStubInstance(ApiPromise);
         stubbedRewardsApi = sinon.createStubInstance(DefaultRewardsAPI);
+        stubbedTransactionApi = sinon.createStubInstance(DefaultTransactionAPI);
         vaultsApi = new DefaultVaultsAPI(
+            stubbedApiPromise as any,
             null as any,
-            null as any,
-            null as any,
+            testWrappedCurrency,
             null as any,
             null as any,
             null as any,
             null as any,
             stubbedRewardsApi,
             null as any,
-            null as any,
+            stubbedTransactionApi,
             null as any
         );
     });
@@ -111,6 +119,51 @@ describe("DefaultVaultsAPI", () => {
                 proportion.toString(),
                 expectedProportion.toString(),
                 `Expected actual proportion to be ${expectedProportion.toString()} but it was ${proportion.toString()}`
+            );
+        });
+    });
+
+    describe("registerNewCollateralVault", () => {
+        const testCollateralAmount = newMonetaryAmount(new Big(30), testCollateralCurrency);
+        it("should reject if transaction API account id is not set", async () => {
+            prepareRegisterNewCollateralVaultMocks(sinon, vaultsApi, stubbedTransactionApi, true);
+
+            const voidPromise = vaultsApi.registerNewCollateralVault(testCollateralAmount);
+            // check for partial string here
+            expect(voidPromise).to.be.rejectedWith("account must be set");
+        });
+
+        it("should reject with same message if transactionApi.sendLogged rejects", async () => {
+            prepareRegisterNewCollateralVaultMocks(sinon, vaultsApi, stubbedTransactionApi, false, true);
+
+            expect(vaultsApi.registerNewCollateralVault(testCollateralAmount)).to.be.rejectedWith(
+                MOCKED_SEND_LOGGED_ERR_MSG
+            );
+        });
+
+        it("should submit call to register new vault with new collateral currency", async () => {
+            const submittedMockExtrinsic = prepareRegisterNewCollateralVaultMocks(
+                sinon,
+                vaultsApi,
+                stubbedTransactionApi
+            );
+            // check precondition
+            assert.isFalse(
+                submittedMockExtrinsic == null,
+                "Test setup error: Expected submitted mock extrinsic to be set, but it was not."
+            );
+
+            expect(vaultsApi.registerNewCollateralVault(testCollateralAmount)).to.be.fulfilled;
+            expect(stubbedTransactionApi.sendLogged.callCount).to.be.equal(
+                1,
+                `Expected transactionApi.sendLogged to be called exactly once, 
+                but it was called ${stubbedTransactionApi.sendLogged.callCount} times`
+            );
+
+            const actualSubmittedExtrinsic = stubbedTransactionApi.sendLogged.getCall(0).args[0];
+            expect(actualSubmittedExtrinsic).to.be.equal(
+                submittedMockExtrinsic,
+                `Expected submitted mock extrinsic have been submitted, but found this instead: ${actualSubmittedExtrinsic.toString()}`
             );
         });
     });


### PR DESCRIPTION
Add api to allow the connected account to register another collateral currency. Assuming the account id is already running a vault with another collateral currency.

-----
Signature in `VaultsAPI`:
```
    /**
     * Registers a new vault for the current account ID with a new collateral amount.
     * Only applicable if the connected account ID already has a running vault with a different collateral currency.
     *
     * Rejects with an Error if unable to register.
     *
     * @param collateralAmount The collateral amount to register the vault with - in the new collateral currency
     */
    registerNewCollateralVault(collateralAmount: MonetaryAmount<CollateralCurrencyExt>): Promise<void>;
```