### PR TITLE
Chore: upgrade interbtc-types 1.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@interlay/interbtc-api",
-  "version": "1.16.2",
+  "version": "1.16.3",
   "description": "JavaScript library to interact with interBTC and kBTC",
   "main": "build/src/index.js",
   "typings": "build/src/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   "engineStrict": true,
   "dependencies": {
     "@interlay/esplora-btc-api": "0.4.0",
-    "@interlay/interbtc-types": "1.7.0",
+    "@interlay/interbtc-types": "1.8.0",
     "@interlay/monetary-js": "0.7.0",
     "@polkadot/api": "8.8.2",
     "@types/big.js": "6.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@interlay/interbtc-api",
-  "version": "1.16.3",
+  "version": "1.16.4",
   "description": "JavaScript library to interact with interBTC and kBTC",
   "main": "build/src/index.js",
   "typings": "build/src/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@interlay/interbtc-api",
-  "version": "1.16.4",
+  "version": "1.16.2",
   "description": "JavaScript library to interact with interBTC and kBTC",
   "main": "build/src/index.js",
   "typings": "build/src/index.d.ts",

--- a/src/parachain/vaults.ts
+++ b/src/parachain/vaults.ts
@@ -35,7 +35,7 @@ import {
     GovernanceCurrency,
 } from "../types";
 import { RewardsAPI } from "./rewards";
-import { BalanceWrapper, UnsignedFixedPoint } from "../interfaces";
+import { UnsignedFixedPoint } from "../interfaces";
 import { AssetRegistryAPI, SystemAPI } from "./index";
 
 /**
@@ -713,7 +713,8 @@ export class DefaultVaultsAPI implements VaultsAPI {
             account_id: vaultId.accountId,
             currencies: vaultId.currencies,
         });
-        const currency = await currencyIdToMonetaryCurrency(this.assetRegistryAPI, balance.currencyId);
+        const wrappedCurrencyPrimitive = newCurrencyId(this.api, this.getWrappedCurrency());
+        const currency = await currencyIdToMonetaryCurrency(this.assetRegistryAPI, wrappedCurrencyPrimitive);
         const amount = newMonetaryAmount(balance.amount.toString(), currency);
         return amount;
     }
@@ -861,13 +862,6 @@ export class DefaultVaultsAPI implements VaultsAPI {
     async getPunishmentFee(): Promise<Big> {
         const fee = await this.api.query.fee.punishmentFee();
         return decodeFixedPointType(fee);
-    }
-
-    private wrapCurrency(amount: MonetaryAmount<CollateralCurrencyExt>): BalanceWrapper {
-        return this.api.createType("BalanceWrapper", {
-            amount: this.api.createType("u128", amount.toString(true)),
-            currencyId: newCurrencyId(this.api, amount.currency),
-        });
     }
 
     private parseVaultStatus(status: VaultRegistryVaultStatus): VaultStatusExt {

--- a/src/utils/encoding.ts
+++ b/src/utils/encoding.ts
@@ -1,5 +1,5 @@
 import { AccountId, H256 } from "@polkadot/types/interfaces";
-import Big from "big.js";
+import Big, { BigSource } from "big.js";
 import { ApiPromise } from "@polkadot/api";
 import type { Struct } from "@polkadot/types";
 import { Network } from "bitcoinjs-lib";
@@ -24,7 +24,7 @@ import {
 import { currencyIdToMonetaryCurrency, encodeBtcAddress, FIXEDI128_SCALING_FACTOR, isForeignAsset } from ".";
 import { SystemVaultExt } from "../types/vault";
 import { Issue, IssueStatus, Redeem, RedeemStatus, RefundRequestExt, ReplaceRequestExt } from "../types/requestTypes";
-import { SignedFixedPoint, UnsignedFixedPoint } from "../interfaces";
+import { BalanceWrapper, SignedFixedPoint, UnsignedFixedPoint } from "../interfaces";
 import { CollateralCurrencyExt, CurrencyExt, WrappedCurrency } from "../types";
 import { newMonetaryAmount } from "../utils";
 import { AssetRegistryAPI, VaultsAPI } from "../parachain";
@@ -189,6 +189,12 @@ export function newCurrencyId(api: ApiPromise, currency: CurrencyExt): InterbtcP
 
 export function newForeignAssetId(api: ApiPromise, id: number): u32 {
     return api.createType("u32", id);
+}
+
+export function newBalanceWrapper(api: ApiPromise, atomicAmount: BigSource): BalanceWrapper {
+    return api.createType("BalanceWrapper", {
+        amount: api.createType("Text", Big(atomicAmount).toString()),
+    });
 }
 
 export function parseRefundRequest(


### PR DESCRIPTION
Bump interbtc-types to version 1.8.0 (changes to `BalanceWrapper`).
Fix resulting syntax errors.

Moved one helper method out of vaults and into encoding.ts where it can accessed.