### PR TITLE
feat: add getter for custom secure collateral threshold

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@interlay/interbtc-api",
-  "version": "1.16.3",
+  "version": "1.16.4",
   "description": "JavaScript library to interact with interBTC and kBTC",
   "main": "build/src/index.js",
   "typings": "build/src/index.d.ts",

--- a/src/parachain/issue.ts
+++ b/src/parachain/issue.ts
@@ -373,6 +373,6 @@ export class DefaultIssueAPI implements IssueAPI {
         vaultAccountId: AccountId,
         collateralCurrency: CollateralCurrencyExt
     ): Promise<MonetaryAmount<WrappedCurrency>> {
-        return this.vaultsAPI.getIssueableTokensFromVault(vaultAccountId, collateralCurrency);
+        return this.vaultsAPI.getIssuableTokensFromVault(vaultAccountId, collateralCurrency);
     }
 }

--- a/src/parachain/vaults.ts
+++ b/src/parachain/vaults.ts
@@ -176,8 +176,9 @@ export interface VaultsAPI {
      */
     getPremiumRedeemThreshold(collateralCurrency: CollateralCurrencyExt): Promise<Big>;
     /**
+     * Get the global secure collateral threshold.
      * @param collateralCurrency
-     * @returns The over-collateralization rate for collateral locked
+     * @returns The global over-collateralization rate for collateral locked
      * by Vaults, necessary for issuing wrapped tokens
      */
     getSecureCollateralThreshold(collateralCurrency: CollateralCurrencyExt): Promise<Big>;
@@ -919,6 +920,11 @@ export class DefaultVaultsAPI implements VaultsAPI {
         const replaceCollateral = newMonetaryAmount(vault.replaceCollateral.toString(), collateralCurrency);
         const liquidatedCollateral = newMonetaryAmount(vault.liquidatedCollateral.toString(), collateralCurrency);
         const backingCollateral = await this.computeBackingCollateral(vault.id);
+
+        const secureThreshold = vault.secureCollateralThreshold.isSome
+            ? decodeFixedPointType(vault.secureCollateralThreshold.unwrap())
+            : await this.getSecureCollateralThreshold(collateralCurrency);
+
         return new VaultExt(
             this.api,
             this.oracleAPI,
@@ -933,7 +939,8 @@ export class DefaultVaultsAPI implements VaultsAPI {
             newMonetaryAmount(vault.toBeRedeemedTokens.toString(), this.wrappedCurrency),
             newMonetaryAmount(vault.toBeReplacedTokens.toString(), this.wrappedCurrency),
             replaceCollateral,
-            liquidatedCollateral
+            liquidatedCollateral,
+            secureThreshold
         );
     }
 

--- a/src/parachain/vaults.ts
+++ b/src/parachain/vaults.ts
@@ -243,7 +243,7 @@ export interface VaultsAPI {
      * @param collateralCurrency The currency specification, a `Monetary.js` object or `ForeignAsset`
      * @returns The issuable amount of a vault
      */
-    getIssueableTokensFromVault(
+    getIssuableTokensFromVault(
         vaultAccountId: AccountId,
         collateralCurrency: CollateralCurrencyExt
     ): Promise<MonetaryAmount<WrappedCurrency>>;
@@ -742,7 +742,7 @@ export class DefaultVaultsAPI implements VaultsAPI {
         }
     }
 
-    async getIssueableTokensFromVault(
+    async getIssuableTokensFromVault(
         vaultAccountId: AccountId,
         collateralCurrency: CollateralCurrencyExt
     ): Promise<MonetaryAmount<WrappedCurrency>> {


### PR DESCRIPTION
Add getter to `VaultExt` to get secure collateral threshold for the vault at hand. If no custom threshold is set, it returns the global one (same as `VaultsApi.getSecureCollateralThreshold()`).

Fixed typo in VaultsAPI method `getIssuableTokensFromVault`