### PR TITLE
feat: add electrs helper to get tx by largest payment

### DIFF
--- a/src/external/electrs.ts
+++ b/src/external/electrs.ts
@@ -98,7 +98,19 @@ export interface ElectrsAPI {
      */
     getTxIdByOpReturn(opReturn: string, recipientAddress?: string, amount?: BitcoinAmount): Promise<string>;
     /**
-     * Fetch the earliest bitcoin transaction ID based on the recipient address and amount.
+     * Fetch the bitcoin transaction ID with the largest payment based on the recipient address.
+     * Throw an error if no transactions are found.
+     *
+     * @remarks
+     * Performs the lookup using an external service, Esplora
+     *
+     * @param recipientAddress Match the receiving address of a transaction output
+     *
+     * @returns A Bitcoin transaction ID
+     */
+    getLargestPaymentToRecipientAddressTxId(recipientAddress: string): Promise<string>;
+    /**
+     * Fetch the oldest bitcoin transaction ID based on the recipient address and amount.
      * Throw an error if no such transaction is found.
      *
      * @remarks
@@ -109,7 +121,7 @@ export interface ElectrsAPI {
      *
      * @returns A Bitcoin transaction ID
      */
-    getEarliestPaymentToRecipientAddressTxId(recipientAddress: string, amount?: BitcoinAmount): Promise<string>;
+    getOldestPaymentToRecipientAddressTxId(recipientAddress: string, amount?: BitcoinAmount): Promise<string>;
     /**
      * Fetch the Bitcoin transaction that matches the given TxId
      *
@@ -227,16 +239,47 @@ export class DefaultElectrsAPI implements ElectrsAPI {
         return amount;
     }
 
-    async getEarliestPaymentToRecipientAddressTxId(recipientAddress: string, amount?: BitcoinAmount): Promise<string> {
+    async getLargestPaymentToRecipientAddressTxId(recipientAddress: string): Promise<string> {
         try {
-            const txes = await this.getData(this.addressApi.getAddressTxHistory(recipientAddress));
-            if (txes.length >= 25) {
+            // TODO: this should be paged
+            const txs = await this.getData(this.addressApi.getAddressTxHistory(recipientAddress));
+            if (txs.length >= 25) {
+                throw new Error("Too many transactions");
+            }
+
+            let txid: string | undefined = undefined;
+            let amount = 0;
+            for (const tx of txs) {
+                if (tx.vout === undefined) {
+                    continue;
+                }
+                for (const vout of tx.vout) {
+                    if (vout.value && vout.scriptpubkey_address === recipientAddress) {
+                        if (vout.value > amount) {
+                            amount = vout.value;
+                            txid = tx.txid;
+                        }
+                    }
+                }
+            }
+            if (txid) return txid;
+        } catch (e) {
+            return Promise.reject(new Error(`Error during tx lookup by address: ${e}`));
+        }
+        return Promise.reject(new Error("No transaction found for recipient"));
+    }
+
+    async getOldestPaymentToRecipientAddressTxId(recipientAddress: string, amount?: BitcoinAmount): Promise<string> {
+        try {
+            // TODO: this should be paged
+            const txs = await this.getData(this.addressApi.getAddressTxHistory(recipientAddress));
+            if (txs.length >= 25) {
                 throw new Error(
                     "Over 25 transactions returned; this is either a highly non-standard vault, or not a vault address"
                 );
             }
 
-            const oldestTx = txes.pop();
+            const oldestTx = txs.pop();
             if (!oldestTx || !oldestTx.vout) {
                 throw new Error("No transaction found for recipient and amount");
             }
@@ -281,6 +324,7 @@ export class DefaultElectrsAPI implements ElectrsAPI {
 
         let txs: Transaction[] = [];
         try {
+            // TODO: this should be paged
             txs = await this.getData(this.scripthashApi.getTxsByScripthash(hash));
         } catch (e) {
             return Promise.reject(new Error(`Error during tx lookup by OP_RETURN: ${e}`));

--- a/test/integration/external/staging/electrs.test.ts
+++ b/test/integration/external/staging/electrs.test.ts
@@ -47,7 +47,7 @@ describe("ElectrsAPI regtest", function () {
 
             const txData = await bitcoinCoreClient.broadcastTx(recipientAddress, amount);
             const txid = await waitSuccess(() =>
-                electrsAPI.getEarliestPaymentToRecipientAddressTxId(recipientAddress, amount)
+                electrsAPI.getOldestPaymentToRecipientAddressTxId(recipientAddress, amount)
             );
             assert.strictEqual(txid, txData.txid);
         });


### PR DESCRIPTION
Signed-off-by: Gregory Hill <gregorydhill@outlook.com>

There may be multiple Bitcoin transactions corresponding to an issue payment, if the user needs to "manually execute" this we should always show the highest amount not the oldest payment since a Vault may trick a user into executing the smaller amount.

We can probably remove or deprecate `getOldestPaymentToRecipientAddressTxId` later.

Not sure if we need to adjust `getTxIdByOpReturn` - would depend on where that is used.