### PR TITLE
chore: revert name change for ElectrsAPI.getEarliestPaymentToRecipientAddressTxId

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@interlay/interbtc-api",
-  "version": "1.16.4",
+  "version": "1.16.5",
   "description": "JavaScript library to interact with interBTC and kBTC",
   "main": "build/src/index.js",
   "typings": "build/src/index.d.ts",

--- a/src/external/electrs.ts
+++ b/src/external/electrs.ts
@@ -110,7 +110,7 @@ export interface ElectrsAPI {
      */
     getLargestPaymentToRecipientAddressTxId(recipientAddress: string): Promise<string>;
     /**
-     * Fetch the oldest bitcoin transaction ID based on the recipient address and amount.
+     * Fetch the earliest/oldest bitcoin transaction ID based on the recipient address and amount.
      * Throw an error if no such transaction is found.
      *
      * @remarks
@@ -120,8 +120,9 @@ export interface ElectrsAPI {
      * @param amount Match the amount (in BTC) of a transaction output that contains said recipientAddress.
      *
      * @returns A Bitcoin transaction ID
+     * @deprecated For most cases where this is used today, {@link getLargestPaymentToRecipientAddressTxId} is better suited.
      */
-    getOldestPaymentToRecipientAddressTxId(recipientAddress: string, amount?: BitcoinAmount): Promise<string>;
+    getEarliestPaymentToRecipientAddressTxId(recipientAddress: string, amount?: BitcoinAmount): Promise<string>;
     /**
      * Fetch the Bitcoin transaction that matches the given TxId
      *
@@ -269,7 +270,7 @@ export class DefaultElectrsAPI implements ElectrsAPI {
         return Promise.reject(new Error("No transaction found for recipient"));
     }
 
-    async getOldestPaymentToRecipientAddressTxId(recipientAddress: string, amount?: BitcoinAmount): Promise<string> {
+    async getEarliestPaymentToRecipientAddressTxId(recipientAddress: string, amount?: BitcoinAmount): Promise<string> {
         try {
             // TODO: this should be paged
             const txs = await this.getData(this.addressApi.getAddressTxHistory(recipientAddress));

--- a/test/integration/external/staging/electrs.test.ts
+++ b/test/integration/external/staging/electrs.test.ts
@@ -40,15 +40,13 @@ describe("ElectrsAPI regtest", function () {
         await api.disconnect();
     });
 
-    it("should getTxIdByRecipientAddress", async () => {
+    it("should getLargestPaymentToRecipientAddressTxId", async () => {
         await runWhileMiningBTCBlocks(bitcoinCoreClient, async () => {
             const recipientAddress = makeRandomBitcoinAddress();
             const amount = new BitcoinAmount(0.00022244);
 
             const txData = await bitcoinCoreClient.broadcastTx(recipientAddress, amount);
-            const txid = await waitSuccess(() =>
-                electrsAPI.getOldestPaymentToRecipientAddressTxId(recipientAddress, amount)
-            );
+            const txid = await waitSuccess(() => electrsAPI.getLargestPaymentToRecipientAddressTxId(recipientAddress));
             assert.strictEqual(txid, txData.txid);
         });
     });


### PR DESCRIPTION
Changes:
- revert name change (from PR https://github.com/interlay/interbtc-api/pull/458),
- mark method as deprecated (use `getLargestPaymentToRecipientAddressTxId` instead),
- bump version