### PR TITLE
feat: add method to get exchange rate for liquidation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@interlay/interbtc-api",
-  "version": "1.16.6",
+  "version": "1.16.7",
   "description": "JavaScript library to interact with interBTC and kBTC",
   "main": "build/src/index.js",
   "typings": "build/src/index.d.ts",

--- a/src/parachain/vaults.ts
+++ b/src/parachain/vaults.ts
@@ -339,6 +339,19 @@ export interface VaultsAPI {
      * @param collateralAmount The collateral amount to register the vault with - in the new collateral currency
      */
     registerNewCollateralVault(collateralAmount: MonetaryAmount<CollateralCurrencyExt>): Promise<void>;
+    /**
+     * Get the target exchange rate at which a vault will be forced to liquidate, given its
+     * current locked collateral and issued as well as to be issued tokens.
+     *
+     * @param vaultAccountId The vault's account ID
+     * @param collateralCurrency The collateral currency for the vault with the account id above
+     * @returns The theoretical collateral per wrapped currency rate below which the vault would be liquidated.
+     *  Returns undefined if a value cannot be calculated, eg. if the vault has no issued tokens.
+     */
+    getExchangeRateForLiquidation(
+        vaultAccountId: AccountId,
+        collateralCurrency: CollateralCurrencyExt
+    ): Promise<Big | undefined>;
 }
 
 export class DefaultVaultsAPI implements VaultsAPI {
@@ -521,14 +534,13 @@ export class DefaultVaultsAPI implements VaultsAPI {
         collateralCurrency: CollateralCurrencyExt,
         governanceCurrency: GovernanceCurrency
     ): Promise<Big> {
-        const vault = await this.get(vaultAccountId, collateralCurrency);
         const [globalRewardPerBlock, globalStake, vaultStake, vaultRewardShare, lockedCollateral, minimumBlockPeriod] =
             await Promise.all([
                 this.rewardsAPI.getRewardPerBlock(governanceCurrency),
                 this.getTotalIssuedAmount(),
                 this.getIssuedAmount(vaultAccountId, collateralCurrency),
                 this.backingCollateralProportion(vaultAccountId, nominatorId, collateralCurrency),
-                this.getLockedCollateral(vault),
+                this.getLockedCollateral(vaultAccountId, collateralCurrency),
                 this.api.consts.timestamp.minimumPeriod,
             ]);
 
@@ -546,13 +558,11 @@ export class DefaultVaultsAPI implements VaultsAPI {
         return this.feeAPI.calculateAPY(annualisedReward, lockedCollateral);
     }
 
-    async getLockedCollateral(vaultExt: VaultExt): Promise<MonetaryAmount<CurrencyExt>> {
-        return (
-            await this.tokensAPI.balance(
-                await currencyIdToMonetaryCurrency(this.assetRegistryAPI, vaultExt.id.currencies.collateral),
-                vaultExt.id.accountId
-            )
-        ).reserved;
+    async getLockedCollateral(
+        vaultAccountId: AccountId,
+        collateralCurrency: CollateralCurrencyExt
+    ): Promise<MonetaryAmount<CurrencyExt>> {
+        return (await this.tokensAPI.balance(collateralCurrency, vaultAccountId)).reserved;
     }
 
     async computeReward(
@@ -879,10 +889,9 @@ export class DefaultVaultsAPI implements VaultsAPI {
     }
 
     async getAPY(vaultAccountId: AccountId, collateralCurrency: CollateralCurrencyExt): Promise<Big> {
-        const vault = await this.get(vaultAccountId, collateralCurrency);
         const [feesWrapped, lockedCollateral, blockRewardsAPY] = await Promise.all([
             this.getWrappedReward(vaultAccountId, collateralCurrency),
-            this.getLockedCollateral(vault),
+            this.getLockedCollateral(vaultAccountId, collateralCurrency),
             this.getBlockRewardAPY(vaultAccountId, vaultAccountId, collateralCurrency, this.governanceCurrency),
         ]);
         return (await this.feeAPI.calculateAPY(feesWrapped, lockedCollateral)).add(blockRewardsAPY);
@@ -949,5 +958,32 @@ export class DefaultVaultsAPI implements VaultsAPI {
         const currencyPair = vaultId.currencies;
         const tx = this.api.tx.vaultRegistry.acceptNewIssues(currencyPair, acceptNewIssues);
         await this.transactionAPI.sendLogged(tx, this.api.events.system.ExtrinsicSuccess, true);
+    }
+
+    async getExchangeRateForLiquidation(
+        vaultAccountId: AccountId,
+        collateralCurrency: CollateralCurrencyExt
+    ): Promise<Big | undefined> {
+        const [vaultExt, liquidationRateThreshold, lockedCollateral] = await Promise.all([
+            this.get(vaultAccountId, collateralCurrency),
+            this.getLiquidationCollateralThreshold(collateralCurrency),
+            this.getLockedCollateral(vaultAccountId, collateralCurrency),
+        ]);
+
+        if (liquidationRateThreshold.eq(0)) {
+            return undefined;
+        }
+
+        const issuedTokens = vaultExt.getBackedTokens();
+
+        if (issuedTokens.toBig().eq(0)) {
+            return undefined;
+        }
+
+        // calculate the theoretical exchange rate at which the vault would be (close to) liquidated
+        const liquidationRateCollaterallPerWrapped = lockedCollateral
+            .toBig()
+            .div(issuedTokens.toBig().mul(liquidationRateThreshold));
+        return liquidationRateCollaterallPerWrapped;
     }
 }

--- a/test/unit/parachain/vaults.test.ts
+++ b/test/unit/parachain/vaults.test.ts
@@ -7,6 +7,7 @@ import {
     prepareBackingCollateralProportionMocks,
     prepareRegisterNewCollateralVaultMocks,
     MOCKED_SEND_LOGGED_ERR_MSG,
+    prepareLiquidationRateMocks,
 } from "../mocks/vaultsTestMocks";
 
 describe("DefaultVaultsAPI", () => {
@@ -162,6 +163,84 @@ describe("DefaultVaultsAPI", () => {
                 submittedMockExtrinsic,
                 `Expected submitted mock extrinsic have been submitted, but found this instead: ${actualSubmittedExtrinsic.toString()}`
             );
+        });
+    });
+
+    describe("getExchangeRateForLiquidation", () => {
+        it("should calculate expected liquidation rate", async () => {
+            const mockIssuedTokens = 1;
+            const mockCollateralTokens = 3;
+            const mockLiquidationThreshold = 2;
+            // expect we need to pay 1.5 KSM per 1 BTC for the collateral (3 KSM) to issued (1 KBTC) ratio
+            // to reach the liquidation threshold rate of 2
+            const expectedLiquidationExchangeRate = 1.5;
+
+            prepareLiquidationRateMocks(
+                sinon,
+                vaultsApi,
+                mockIssuedTokens,
+                mockCollateralTokens,
+                mockLiquidationThreshold,
+                testWrappedCurrency,
+                testCollateralCurrency
+            );
+
+            // get the fictitious liquidation rate
+            const actualRate = await vaultsApi.getExchangeRateForLiquidation(
+                null as never, // this variable is ignored, mocked away
+                testCollateralCurrency
+            );
+
+            expect(actualRate).to.not.be.undefined;
+            expect(actualRate?.toNumber()).eq(expectedLiquidationExchangeRate);
+        });
+
+        it("should return undefined if vault has no issued tokens", async () => {
+            const mockIssuedTokens = 0;
+            const mockCollateralTokens = 3;
+            const mockLiquidationThreshold = 2;
+
+            prepareLiquidationRateMocks(
+                sinon,
+                vaultsApi,
+                mockIssuedTokens,
+                mockCollateralTokens,
+                mockLiquidationThreshold,
+                testWrappedCurrency,
+                testCollateralCurrency
+            );
+
+            // get the fictitious liquidation rate
+            const actualRate = await vaultsApi.getExchangeRateForLiquidation(
+                null as never, // this variable is ignored, mocked away
+                testCollateralCurrency
+            );
+
+            expect(actualRate).to.be.undefined;
+        });
+
+        it("should return undefined if liquidation rate is zero", async () => {
+            const mockIssuedTokens = 1;
+            const mockCollateralTokens = 3;
+            const mockLiquidationThreshold = 0;
+
+            prepareLiquidationRateMocks(
+                sinon,
+                vaultsApi,
+                mockIssuedTokens,
+                mockCollateralTokens,
+                mockLiquidationThreshold,
+                testWrappedCurrency,
+                testCollateralCurrency
+            );
+
+            // get the fictitious liquidation rate
+            const actualRate = await vaultsApi.getExchangeRateForLiquidation(
+                null as never, // this variable is ignored, mocked away
+                testCollateralCurrency
+            );
+
+            expect(actualRate).to.be.undefined;
         });
     });
 });


### PR DESCRIPTION
New method for `VaultsAPI`:
```
    /**
     * Get the target exchange rate at which a vault will be forced to liquidate, given its
     * current locked collateral and issued as well as to be issued tokens.
     *
     * @param vaultAccountId The vault's account ID
     * @param collateralCurrency The collateral currency for the vault with the account id above
     * @returns The theoretical collateral per wrapped currency rate below which the vault would be liquidated.
     *  Returns undefined if a value cannot be calculated, eg. if the vault has no issued tokens.
     */
    getExchangeRateForLiquidation(
        vaultAccountId: AccountId,
        collateralCurrency: CollateralCurrencyExt
    ): Promise<Big | undefined>;
```