### PR TITLE
Feat: fetch collateral currencies from chain

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@interlay/interbtc-api",
-  "version": "1.16.9",
+  "version": "1.16.10",
   "description": "JavaScript library to interact with interBTC and kBTC",
   "main": "build/src/index.js",
   "typings": "build/src/index.d.ts",

--- a/src/utils/currency.ts
+++ b/src/utils/currency.ts
@@ -96,6 +96,25 @@ export function toVoting(governanceCurrency: GovernanceCurrency): Currency {
 }
 
 /**
+ * Get the collateral currencies (excluding foreign assets) associated with the governance currency.
+ * @param governanceCurrency the governance/native currency for which to return the collateral currencies.
+ * @returns An array of collateral currencies.
+ * @deprecated to be removed at version 1.17.0. Use {@link getCollateralCurrencies} instead.
+ */
+export function getCorrespondingCollateralCurrencies(
+    governanceCurrency: GovernanceCurrency
+): Array<CollateralCurrencyExt> {
+    switch (governanceCurrency.ticker) {
+        case "KINT":
+            return [Kusama, Kintsugi];
+        case "INTR":
+            return [Polkadot];
+        default:
+            throw new Error("Provided currency is not a governance currency");
+    }
+}
+
+/**
  * Get all collateral currencies (tokens as well as foreign assets).
  *
  * Will return all collateral currencies for which the parachain has a system collateral ceiling value

--- a/src/utils/currency.ts
+++ b/src/utils/currency.ts
@@ -95,6 +95,15 @@ export function toVoting(governanceCurrency: GovernanceCurrency): Currency {
     }
 }
 
+/**
+ * Get all collateral currencies (tokens as well as foreign assets).
+ *
+ * Will return all collateral currencies for which the parachain has a system collateral ceiling value
+ * greater than zero.
+ * @param api ApiPromise instance to query the parachain
+ * @param assetRegistry AssetRegistryAPI instance to fetch foreign asset data (if needed)
+ * @returns An array of collateral currencies.
+ */
 export async function getCollateralCurrencies(
     api: ApiPromise,
     assetRegistry: AssetRegistryAPI

--- a/src/utils/setup.ts
+++ b/src/utils/setup.ts
@@ -30,7 +30,7 @@ import {
 } from "../../test/config";
 import { CollateralCurrencyExt, CurrencyExt, WrappedCurrency } from "../types";
 import { newVaultId } from "./encoding";
-import { InterBtcApi, DefaultInterBtcApi, newMonetaryAmount, getCorrespondingCollateralCurrencies } from "../";
+import { InterBtcApi, DefaultInterBtcApi, newMonetaryAmount, getCollateralCurrencies } from "../";
 import { AddressOrPair } from "@polkadot/api/types";
 
 // Command line arguments of the initialization script
@@ -213,7 +213,10 @@ async function main(params: InitializationParams): Promise<void> {
     const sudoAccountInterBtcApi = new DefaultInterBtcApi(api, "regtest", sudoAccount, ESPLORA_BASE_PATH);
 
     const wrappedCurrency = sudoAccountInterBtcApi.getWrappedCurrency();
-    const collateralCurrencies = getCorrespondingCollateralCurrencies(sudoAccountInterBtcApi.getGovernanceCurrency());
+    const collateralCurrencies = await getCollateralCurrencies(
+        sudoAccountInterBtcApi.api,
+        sudoAccountInterBtcApi.assetRegistry
+    );
     // TODO: figure out if we want to initialize alternative collateral currencies (like KINT in additon to KSM), too?
     const collateralCurrency = collateralCurrencies[0];
 

--- a/test/integration/parachain/release/redeem.test.ts
+++ b/test/integration/parachain/release/redeem.test.ts
@@ -28,7 +28,7 @@ import {
     VAULT_1_URI,
 } from "../../../config";
 import { BitcoinCoreClient } from "../../../../src/utils/bitcoin-core-client";
-import { getCorrespondingCollateralCurrencies, issueSingle, newMonetaryAmount } from "../../../../src/utils";
+import { issueSingle, newMonetaryAmount } from "../../../../src/utils";
 import {
     CollateralCurrencyExt,
     DefaultTransactionAPI,
@@ -40,7 +40,7 @@ import {
     WrappedCurrency,
 } from "../../../../src";
 import { assert, expect } from "../../../chai";
-import { runWhileMiningBTCBlocks, sudo } from "../../../utils/helpers";
+import { getCorrespondingCollateralCurrenciesForTests, runWhileMiningBTCBlocks, sudo } from "../../../utils/helpers";
 
 export type RequestResult = { hash: Hash; vault: VaultRegistryVault };
 
@@ -72,7 +72,7 @@ describe("redeem", () => {
         userInterBtcAPI = new DefaultInterBtcApi(api, "regtest", userAccount, ESPLORA_BASE_PATH);
         oracleInterBtcAPI = new DefaultInterBtcApi(api, "regtest", oracleAccount, ESPLORA_BASE_PATH);
         reporterInterBtcAPI = new DefaultInterBtcApi(api, "regtest", reportingVaultAccount, ESPLORA_BASE_PATH);
-        collateralCurrencies = getCorrespondingCollateralCurrencies(userInterBtcAPI.getGovernanceCurrency());
+        collateralCurrencies = getCorrespondingCollateralCurrenciesForTests(userInterBtcAPI.getGovernanceCurrency());
         wrappedCurrency = userInterBtcAPI.getWrappedCurrency();
         vaultToLiquidate = keyring.addFromUri(VAULT_TO_LIQUIDATE_URI);
         vaultToLiquidateIds = collateralCurrencies.map((collateralCurrency) =>

--- a/test/integration/parachain/staging/fee.test.ts
+++ b/test/integration/parachain/staging/fee.test.ts
@@ -8,13 +8,12 @@ import { ESPLORA_BASE_PATH, ORACLE_URI, PARACHAIN_ENDPOINT } from "../../../conf
 import {
     CollateralCurrencyExt,
     DefaultInterBtcApi,
-    getCorrespondingCollateralCurrencies,
     InterBtcApi,
     newMonetaryAmount,
     WrappedCurrency,
 } from "../../../../src";
 import { GriefingCollateralType } from "../../../../src/parachain/fee";
-import { callWithExchangeRate } from "../../../utils/helpers";
+import { callWithExchangeRate, getCorrespondingCollateralCurrenciesForTests } from "../../../utils/helpers";
 
 describe("fee", () => {
     let api: ApiPromise;
@@ -27,7 +26,7 @@ describe("fee", () => {
         const keyring = new Keyring({ type: "sr25519" });
         const oracleAccount = keyring.addFromUri(ORACLE_URI);
         oracleInterBtcAPI = new DefaultInterBtcApi(api, "regtest", oracleAccount, ESPLORA_BASE_PATH);
-        collateralCurrencies = getCorrespondingCollateralCurrencies(oracleInterBtcAPI.getGovernanceCurrency());
+        collateralCurrencies = getCorrespondingCollateralCurrenciesForTests(oracleInterBtcAPI.getGovernanceCurrency());
         wrappedCurrency = oracleInterBtcAPI.getWrappedCurrency();
     });
 

--- a/test/integration/parachain/staging/sequential/issue.test.ts
+++ b/test/integration/parachain/staging/sequential/issue.test.ts
@@ -5,7 +5,6 @@ import {
     CollateralCurrencyExt,
     currencyIdToMonetaryCurrency,
     DefaultInterBtcApi,
-    getCorrespondingCollateralCurrencies,
     InterBtcApi,
     InterbtcPrimitivesVaultId,
     IssueStatus,
@@ -30,7 +29,7 @@ import {
 import { BitcoinCoreClient } from "../../../../../src/utils/bitcoin-core-client";
 import { issueSingle } from "../../../../../src/utils/issueRedeem";
 import { newVaultId, WrappedCurrency } from "../../../../../src";
-import { runWhileMiningBTCBlocks, sudo } from "../../../../utils/helpers";
+import { getCorrespondingCollateralCurrenciesForTests, runWhileMiningBTCBlocks, sudo } from "../../../../utils/helpers";
 
 describe("issue", () => {
     let api: ApiPromise;
@@ -52,7 +51,7 @@ describe("issue", () => {
         keyring = new Keyring({ type: "sr25519" });
         userAccount = keyring.addFromUri(USER_1_URI);
         userInterBtcAPI = new DefaultInterBtcApi(api, "regtest", userAccount, ESPLORA_BASE_PATH);
-        collateralCurrencies = getCorrespondingCollateralCurrencies(userInterBtcAPI.getGovernanceCurrency());
+        collateralCurrencies = getCorrespondingCollateralCurrenciesForTests(userInterBtcAPI.getGovernanceCurrency());
         wrappedCurrency = userInterBtcAPI.getWrappedCurrency();
 
         vault_1 = keyring.addFromUri(VAULT_1_URI);

--- a/test/integration/parachain/staging/sequential/nomination.test.ts
+++ b/test/integration/parachain/staging/sequential/nomination.test.ts
@@ -18,12 +18,7 @@ import {
     newVaultId,
     WrappedCurrency,
 } from "../../../../../src";
-import {
-    setNumericStorage,
-    issueSingle,
-    newMonetaryAmount,
-    getCorrespondingCollateralCurrencies,
-} from "../../../../../src/utils";
+import { setNumericStorage, issueSingle, newMonetaryAmount } from "../../../../../src/utils";
 import { createSubstrateAPI } from "../../../../../src/factory";
 import { assert } from "../../../../chai";
 import {
@@ -39,7 +34,7 @@ import {
     PARACHAIN_ENDPOINT,
     ESPLORA_BASE_PATH,
 } from "../../../../config";
-import { callWith, sudo } from "../../../../utils/helpers";
+import { callWith, getCorrespondingCollateralCurrenciesForTests, sudo } from "../../../../utils/helpers";
 import { Nomination } from "../../../../../src/parachain/nomination";
 
 // TODO: readd this once we want to activate nomination
@@ -67,7 +62,7 @@ describe.skip("NominationAPI", () => {
         userInterBtcAPI = new DefaultInterBtcApi(api, "regtest", userAccount, ESPLORA_BASE_PATH);
         sudoInterBtcAPI = new DefaultInterBtcApi(api, "regtest", sudoAccount, ESPLORA_BASE_PATH);
         assetRegistry = new DefaultAssetRegistryAPI(api);
-        collateralCurrencies = getCorrespondingCollateralCurrencies(userInterBtcAPI.getGovernanceCurrency());
+        collateralCurrencies = getCorrespondingCollateralCurrenciesForTests(userInterBtcAPI.getGovernanceCurrency());
         wrappedCurrency = userInterBtcAPI.getWrappedCurrency();
         vault_1 = keyring.addFromUri(VAULT_1_URI);
         vault_1_ids = collateralCurrencies.map((collateralCurrency) =>

--- a/test/integration/parachain/staging/sequential/oracle.test.ts
+++ b/test/integration/parachain/staging/sequential/oracle.test.ts
@@ -5,14 +5,12 @@ import { Bitcoin, BitcoinAmount, ExchangeRate } from "@interlay/monetary-js";
 import { createSubstrateAPI } from "../../../../../src/factory";
 import { assert } from "../../../../chai";
 import { ESPLORA_BASE_PATH, ORACLE_URI, PARACHAIN_ENDPOINT } from "../../../../config";
+import { CollateralCurrencyExt, DefaultInterBtcApi, getSS58Prefix, InterBtcApi } from "../../../../../src";
 import {
-    CollateralCurrencyExt,
-    DefaultInterBtcApi,
-    getCorrespondingCollateralCurrencies,
-    getSS58Prefix,
-    InterBtcApi,
-} from "../../../../../src";
-import { getExchangeRateValueToSetForTesting, ORACLE_MAX_DELAY } from "../../../../utils/helpers";
+    getCorrespondingCollateralCurrenciesForTests,
+    getExchangeRateValueToSetForTesting,
+    ORACLE_MAX_DELAY,
+} from "../../../../utils/helpers";
 
 describe("OracleAPI", () => {
     let api: ApiPromise;
@@ -33,7 +31,7 @@ describe("OracleAPI", () => {
         bobAccount = keyring.addFromUri("//Bob");
         charlieAccount = keyring.addFromUri("//Charlie");
         interBtcAPI = new DefaultInterBtcApi(api, "regtest", oracleAccount, ESPLORA_BASE_PATH);
-        collateralCurrencies = getCorrespondingCollateralCurrencies(interBtcAPI.getGovernanceCurrency());
+        collateralCurrencies = getCorrespondingCollateralCurrenciesForTests(interBtcAPI.getGovernanceCurrency());
     });
 
     after(() => {

--- a/test/integration/parachain/staging/sequential/redeem.test.ts
+++ b/test/integration/parachain/staging/sequential/redeem.test.ts
@@ -25,17 +25,17 @@ import {
     VAULT_2_URI,
     ESPLORA_BASE_PATH,
 } from "../../../../config";
-import {
-    getCorrespondingCollateralCurrencies,
-    issueAndRedeem,
-    newMonetaryAmount,
-    stripHexPrefix,
-} from "../../../../../src/utils";
+import { issueAndRedeem, newMonetaryAmount, stripHexPrefix } from "../../../../../src/utils";
 import { BitcoinCoreClient } from "../../../../../src/utils/bitcoin-core-client";
 import { newVaultId, WrappedCurrency } from "../../../../../src";
 import { ExecuteRedeem } from "../../../../../src/utils/issueRedeem";
 import Big from "big.js";
-import { bumpFeesForBtcTx, calculateBtcTxVsize, getAUSDForeignAsset } from "../../../../utils/helpers";
+import {
+    bumpFeesForBtcTx,
+    calculateBtcTxVsize,
+    getAUSDForeignAsset,
+    getCorrespondingCollateralCurrenciesForTests,
+} from "../../../../utils/helpers";
 
 export type RequestResult = { hash: Hash; vault: VaultRegistryVault };
 
@@ -68,7 +68,7 @@ describe("redeem", () => {
         interBtcAPI = new DefaultInterBtcApi(api, "regtest", userAccount, ESPLORA_BASE_PATH);
         assetRegistry = new DefaultAssetRegistryAPI(api);
 
-        const collateralCurrencies = getCorrespondingCollateralCurrencies(interBtcAPI.getGovernanceCurrency());
+        const collateralCurrencies = getCorrespondingCollateralCurrenciesForTests(interBtcAPI.getGovernanceCurrency());
         wrappedCurrency = interBtcAPI.getWrappedCurrency();
         vault_1 = keyring.addFromUri(VAULT_1_URI);
         vault_2 = keyring.addFromUri(VAULT_2_URI);

--- a/test/integration/parachain/staging/sequential/redeem.test.ts
+++ b/test/integration/parachain/staging/sequential/redeem.test.ts
@@ -43,7 +43,6 @@ describe("redeem", () => {
     let api: ApiPromise;
     let keyring: Keyring;
     let userAccount: KeyringPair;
-    const randomBtcAddress = "bcrt1qujs29q4gkyn2uj6y570xl460p4y43ruayxu8ry";
     let bitcoinCoreClient: BitcoinCoreClient;
     let vault_1: KeyringPair;
     let vault_2: KeyringPair;

--- a/test/integration/parachain/staging/sequential/replace.test.ts
+++ b/test/integration/parachain/staging/sequential/replace.test.ts
@@ -4,7 +4,6 @@ import {
     AssetRegistryAPI,
     DefaultAssetRegistryAPI,
     DefaultInterBtcApi,
-    getCorrespondingCollateralCurrencies,
     InterBtcApi,
     InterbtcPrimitivesVaultId,
     newMonetaryAmount,
@@ -29,7 +28,7 @@ import { assert, expect } from "../../../../chai";
 import { issueSingle } from "../../../../../src/utils/issueRedeem";
 import { currencyIdToMonetaryCurrency, newAccountId, newVaultId, WrappedCurrency } from "../../../../../src";
 import { MonetaryAmount } from "@interlay/monetary-js";
-import { callWith, waitForEvent } from "../../../../utils/helpers";
+import { callWith, getCorrespondingCollateralCurrenciesForTests, waitForEvent } from "../../../../utils/helpers";
 
 describe("replace", () => {
     let api: ApiPromise;
@@ -61,7 +60,7 @@ describe("replace", () => {
         assetRegistry = new DefaultAssetRegistryAPI(api);
         interBtcAPI = new DefaultInterBtcApi(api, "regtest", userAccount, ESPLORA_BASE_PATH);
         wrappedCurrency = interBtcAPI.getWrappedCurrency();
-        const collateralCurrencies = getCorrespondingCollateralCurrencies(interBtcAPI.getGovernanceCurrency());
+        const collateralCurrencies = getCorrespondingCollateralCurrenciesForTests(interBtcAPI.getGovernanceCurrency());
         vault_3 = keyring.addFromUri(VAULT_3_URI);
         vault_3_ids = collateralCurrencies.map((collateralCurrency) =>
             newVaultId(api, vault_3.address, collateralCurrency, wrappedCurrency)

--- a/test/integration/parachain/staging/sequential/vaults.test.ts
+++ b/test/integration/parachain/staging/sequential/vaults.test.ts
@@ -26,8 +26,13 @@ import {
     ESPLORA_BASE_PATH,
 } from "../../../../config";
 import { newAccountId, WrappedCurrency, newVaultId } from "../../../../../src";
-import { getCorrespondingCollateralCurrencies, getSS58Prefix, newMonetaryAmount } from "../../../../../src/utils";
-import { AUSD_TICKER, getAUSDForeignAsset, vaultStatusToLabel } from "../../../../utils/helpers";
+import { getSS58Prefix, newMonetaryAmount } from "../../../../../src/utils";
+import {
+    AUSD_TICKER,
+    getAUSDForeignAsset,
+    getCorrespondingCollateralCurrenciesForTests,
+    vaultStatusToLabel,
+} from "../../../../utils/helpers";
 import sinon from "sinon";
 
 describe("vaultsAPI", () => {
@@ -56,7 +61,7 @@ describe("vaultsAPI", () => {
         wrappedCurrency = interBtcAPI.getWrappedCurrency();
         governanceCurrency = interBtcAPI.getGovernanceCurrency();
 
-        collateralCurrencies = getCorrespondingCollateralCurrencies(governanceCurrency);
+        collateralCurrencies = getCorrespondingCollateralCurrenciesForTests(governanceCurrency);
         const aUSD = await getAUSDForeignAsset(assetRegistry);
         if (aUSD !== undefined) {
             // also add aUSD collateral vaults if they exist (ie. the foreign asset exists)

--- a/test/integration/parachain/staging/setup/initialize.test.ts
+++ b/test/integration/parachain/staging/setup/initialize.test.ts
@@ -12,7 +12,6 @@ import {
     newAccountId,
     InterBtcApi,
     DefaultInterBtcApi,
-    getCorrespondingCollateralCurrencies,
     CollateralCurrencyExt,
     CurrencyExt,
     newVaultCurrencyPair,
@@ -20,6 +19,7 @@ import {
     encodeUnsignedFixedPoint,
     setNumericStorage,
     getSS58Prefix,
+    getCollateralCurrencies,
 } from "../../../../../src";
 import {
     initializeVaultNomination,
@@ -48,6 +48,7 @@ import {
     APPROX_BLOCK_TIME_MS,
     AUSD_TICKER,
     getAUSDForeignAsset,
+    getCorrespondingCollateralCurrenciesForTests,
     getExchangeRateValueToSetForTesting,
     ORACLE_MAX_DELAY,
     sleep,
@@ -122,7 +123,7 @@ describe("Initialize parachain state", () => {
         userInterBtcAPI = new DefaultInterBtcApi(api, "regtest", userAccount, ESPLORA_BASE_PATH);
         sudoInterBtcAPI = new DefaultInterBtcApi(api, "regtest", sudoAccount, ESPLORA_BASE_PATH);
 
-        collateralCurrency = getCorrespondingCollateralCurrencies(userInterBtcAPI.getGovernanceCurrency())[0];
+        collateralCurrency = getCorrespondingCollateralCurrenciesForTests(userInterBtcAPI.getGovernanceCurrency())[0];
         const vaultCollateralPairs: [KeyringPair, CollateralCurrencyExt][] = [
             [vault_1, collateralCurrency],
             [vault_2, collateralCurrency],
@@ -317,8 +318,12 @@ describe("Initialize parachain state", () => {
         const sudoThis = async (extrinsic: SubmittableExtrinsic<"promise", ISubmittableResult>) =>
             sudoInterBtcAPI.api.tx.sudo.sudo(extrinsic).signAndSend(sudoAccount);
 
+        const collateralCurrenciesBefore = await getCollateralCurrencies(
+            sudoInterBtcAPI.api,
+            sudoInterBtcAPI.assetRegistry
+        );
         // (unsafely) get first collateral currency's ceiling and thresholds
-        const existingCollCcy = getCorrespondingCollateralCurrencies(sudoInterBtcAPI.getGovernanceCurrency())[0];
+        const existingCollCcy = collateralCurrenciesBefore[0];
         const existingCcyPair = newVaultCurrencyPair(api, existingCollCcy, sudoInterBtcAPI.getWrappedCurrency());
         // borrow values from existing currency pair
         const [optionCeilValue, existingSecureThreshold, existingPremiumThreshold, existingLiquidationThreshold] =
@@ -336,7 +341,8 @@ describe("Initialize parachain state", () => {
         const encodedPremThresh = encodeUnsignedFixedPoint(sudoInterBtcAPI.api, new Big(existingPremiumThreshold));
         const encodedLiqThresh = encodeUnsignedFixedPoint(sudoInterBtcAPI.api, new Big(existingLiquidationThreshold));
 
-        const aUsdCcyPair = newVaultCurrencyPair(api, aUSD, sudoInterBtcAPI.getWrappedCurrency());
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        const aUsdCcyPair = newVaultCurrencyPair(api, aUSD!, sudoInterBtcAPI.getWrappedCurrency());
 
         // set the collateral ceiling
         const setCeilingExtrinsic = sudoInterBtcAPI.api.tx.vaultRegistry.setSystemCollateralCeiling(
@@ -379,6 +385,17 @@ describe("Initialize parachain state", () => {
         assert.isTrue(
             foundEvent,
             `Cannot find Sudid event for setting thresholds in batch - timeout after ${timeoutMs} ms`
+        );
+
+        const collateralCurrenciesAfter = await getCollateralCurrencies(
+            userInterBtcAPI.api,
+            userInterBtcAPI.assetRegistry
+        );
+
+        assert.isDefined(
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            collateralCurrenciesAfter.find((currency) => currency.ticker === aUSD!.ticker),
+            "Expected to find aUSD within the array of collateral currencies, but did not"
         );
     });
 

--- a/test/integration/parachain/staging/setup/initialize.test.ts
+++ b/test/integration/parachain/staging/setup/initialize.test.ts
@@ -318,9 +318,10 @@ describe("Initialize parachain state", () => {
         const sudoThis = async (extrinsic: SubmittableExtrinsic<"promise", ISubmittableResult>) =>
             sudoInterBtcAPI.api.tx.sudo.sudo(extrinsic).signAndSend(sudoAccount);
 
-        const collateralCurrencies = await getCollateralCurrencies(sudoInterBtcAPI.api, sudoInterBtcAPI.assetRegistry);
         // (unsafely) get first collateral currency's ceiling and thresholds
-        const existingCollCcy = collateralCurrencies[0];
+        const existingCollCcy = getCorrespondingCollateralCurrenciesForTests(
+            userInterBtcAPI.getGovernanceCurrency()
+        )[0];
         const existingCcyPair = newVaultCurrencyPair(api, existingCollCcy, sudoInterBtcAPI.getWrappedCurrency());
         // borrow values from existing currency pair
         const [optionCeilValue, existingSecureThreshold, existingPremiumThreshold, existingLiquidationThreshold] =

--- a/test/integration/parachain/staging/tokens.test.ts
+++ b/test/integration/parachain/staging/tokens.test.ts
@@ -14,7 +14,7 @@ import {
     newAccountId,
     newMonetaryAmount,
 } from "../../../../src";
-import { getCorrespondingCollateralCurrenciesForTests } from "test/utils/helpers";
+import { getCorrespondingCollateralCurrenciesForTests } from "../../../utils/helpers";
 
 describe("TokensAPI", () => {
     let api: ApiPromise;

--- a/test/integration/parachain/staging/tokens.test.ts
+++ b/test/integration/parachain/staging/tokens.test.ts
@@ -10,11 +10,11 @@ import {
     CollateralCurrencyExt,
     CurrencyExt,
     DefaultInterBtcApi,
-    getCorrespondingCollateralCurrencies,
     InterBtcApi,
     newAccountId,
     newMonetaryAmount,
 } from "../../../../src";
+import { getCorrespondingCollateralCurrenciesForTests } from "test/utils/helpers";
 
 describe("TokensAPI", () => {
     let api: ApiPromise;
@@ -29,7 +29,7 @@ describe("TokensAPI", () => {
         user1Account = keyring.addFromUri(USER_1_URI);
         user2Account = keyring.addFromUri(USER_2_URI);
         interBtcAPI = new DefaultInterBtcApi(api, "regtest", user1Account, ESPLORA_BASE_PATH);
-        collateralCurrencies = getCorrespondingCollateralCurrencies(interBtcAPI.getGovernanceCurrency());
+        collateralCurrencies = getCorrespondingCollateralCurrenciesForTests(interBtcAPI.getGovernanceCurrency());
     });
 
     after(() => {

--- a/test/utils/helpers.ts
+++ b/test/utils/helpers.ts
@@ -1,5 +1,5 @@
 import { Transaction } from "@interlay/esplora-btc-api";
-import { Bitcoin, ExchangeRate } from "@interlay/monetary-js";
+import { Bitcoin, ExchangeRate, Kintsugi, Kusama, Polkadot } from "@interlay/monetary-js";
 import { Keyring } from "@polkadot/api";
 import { ApiTypes, AugmentedEvent } from "@polkadot/api/types";
 import { KeyringPair } from "@polkadot/keyring/types";
@@ -17,6 +17,8 @@ import {
     CurrencyExt,
     AssetRegistryAPI,
     ForeignAsset,
+    GovernanceCurrency,
+    CollateralCurrencyExt,
 } from "../../src";
 import { SUDO_URI } from "../config";
 
@@ -39,7 +41,7 @@ export function sleep(ms: number): Promise<void> {
 }
 
 export async function wait_success<R>(call: () => Promise<R>): Promise<R> {
-    for (; ;) {
+    for (;;) {
         try {
             const res = await call();
             return res;
@@ -277,8 +279,8 @@ export const waitForEvent = async <T extends AnyTuple>(
     const timeoutPromise =
         timeoutMs !== undefined
             ? new Promise<void>((_, reject) => {
-                timeoutHandle = setTimeout(() => reject(), timeoutMs);
-            })
+                  timeoutHandle = setTimeout(() => reject(), timeoutMs);
+              })
             : Promise.resolve();
 
     const waitForEventPromise = finalized
@@ -296,3 +298,17 @@ export const getAUSDForeignAsset = async (assetRegistryApi: AssetRegistryAPI): P
     const foreignAssets = await assetRegistryApi.getForeignAssets();
     return foreignAssets.find((asset) => asset.ticker === AUSD_TICKER);
 };
+
+// for tests: get the collateral currencies (excluding foreign assets) associated with the governance currency
+export function getCorrespondingCollateralCurrenciesForTests(
+    governanceCurrency: GovernanceCurrency
+): Array<CollateralCurrencyExt> {
+    switch (governanceCurrency.ticker) {
+        case "KINT":
+            return [Kusama, Kintsugi];
+        case "INTR":
+            return [Polkadot];
+        default:
+            throw new Error("Provided currency is not a governance currency");
+    }
+}


### PR DESCRIPTION
Fetch collateral currencies based on parachain data, rather than the previously hard-coded token currencies.
The method will now also return foreign assets, as opposed to hard-coded tokens (KINT, INTR, KSM, DOT, etc) only.

------

In `src/utils/currency.ts`
Marked method as deprecated (note of planned removal in the next minor version bump (1.17.0): 
`getCorrespondingCollateralCurrencies(governanceCurrency: GovernanceCurrency): Array<CollateralCurrencyExt>`
To be used instead:
`getCollateralCurrencies(api: ApiPromise, assetRegistry: AssetRegistryAPI): Promise<Array<CollateralCurrencyExt>>`