### PR TITLE
Chore: add mocked endpoint as sample.

### DIFF
--- a/src/interbtc-api.ts
+++ b/src/interbtc-api.ts
@@ -20,7 +20,14 @@ import { BitcoinNetwork } from "./types/bitcoinTypes";
 import { DefaultRewardsAPI, RewardsAPI } from "./parachain/rewards";
 import { DefaultTransactionAPI, TransactionAPI } from "./parachain/transaction";
 import { GovernanceCurrency, WrappedCurrency } from "./types";
-import { DefaultAssetRegistryAPI, DefaultEscrowAPI, EscrowAPI, tokenSymbolToCurrency } from ".";
+import {
+    DefaultAssetRegistryAPI,
+    DefaultEscrowAPI,
+    DefaultLoansAPI,
+    EscrowAPI,
+    LoansAPI,
+    tokenSymbolToCurrency,
+} from ".";
 import { AssetRegistryAPI } from "./parachain/asset-registry";
 
 export * from "./factory";
@@ -80,6 +87,7 @@ export class DefaultInterBtcApi implements InterBtcApi {
     public readonly rewards: RewardsAPI;
     public readonly escrow: EscrowAPI;
     public readonly assetRegistry: AssetRegistryAPI;
+    public readonly loans: LoansAPI;
     private transactionAPI: TransactionAPI;
 
     constructor(
@@ -157,6 +165,8 @@ export class DefaultInterBtcApi implements InterBtcApi {
             this.transactionAPI,
             this.assetRegistry
         );
+
+        this.loans = new DefaultLoansAPI(api, this.assetRegistry);
     }
 
     setAccount(account: AddressOrPair, signer?: Signer): void {

--- a/src/parachain/index.ts
+++ b/src/parachain/index.ts
@@ -12,6 +12,7 @@ export { RewardsAPI, DefaultRewardsAPI } from "./rewards";
 export { NominationAPI, DefaultNominationAPI } from "./nomination";
 export { EscrowAPI, DefaultEscrowAPI } from "./escrow";
 export { AssetRegistryAPI, DefaultAssetRegistryAPI } from "./asset-registry";
+export { LoansAPI, DefaultLoansAPI } from "./loans";
 export * from "./transaction";
 
 // Hacky way of forcing the resolution of these types in test files

--- a/src/parachain/loans.ts
+++ b/src/parachain/loans.ts
@@ -1,0 +1,42 @@
+import { AccountId } from "@polkadot/types/interfaces";
+import { MonetaryAmount } from "@interlay/monetary-js";
+import { CurrencyExt } from "../types";
+import { AssetRegistryAPI } from "./asset-registry";
+import { ApiPromise } from "@polkadot/api";
+
+/**
+ * @category BTC Bridge
+ */
+export interface LoansAPI {
+    /**
+     * Get the current borrowed amount for a given account and currency
+     *
+     * @param accountId the account Id for which to get the borrowed amount
+     * @param currency The currency to retrieve the borrowed amount for
+     * @returns The amount borrowed
+     */
+    getCurrentBorrowBalance(accountId: AccountId, currency: CurrencyExt): Promise<MonetaryAmount<CurrencyExt>>;
+
+    /**
+     * Get the current borrowed amount for a given account and currency
+     *
+     * @param accountId the account Id for which to get the colletaral balance
+     * @param currency The currency to retrieve the collateral balance for
+     * @returns The current collateral amount
+     */
+    getCurrentCollateralBalance(accountId: AccountId, currency: CurrencyExt): Promise<MonetaryAmount<CurrencyExt>>;
+}
+
+export class DefaultLoansAPI implements LoansAPI {
+    constructor(private api: ApiPromise, private assetRegistry: AssetRegistryAPI) {}
+
+    getCurrentBorrowBalance(accountId: AccountId, currency: CurrencyExt): Promise<MonetaryAmount<CurrencyExt>> {
+        // return some mocked amount for the given currency as promise
+        return Promise.resolve(new MonetaryAmount(currency, 4.2));
+    }
+
+    getCurrentCollateralBalance(accountId: AccountId, currency: CurrencyExt): Promise<MonetaryAmount<CurrencyExt>> {
+        // return some mocked amount for the given currency as promise
+        return Promise.resolve(new MonetaryAmount(currency, 12.34567));
+    }
+}

--- a/test/unit/parachain/loans.test.ts
+++ b/test/unit/parachain/loans.test.ts
@@ -1,0 +1,56 @@
+import sinon from "sinon";
+import { ApiPromise } from "@polkadot/api";
+import { DefaultAssetRegistryAPI, DefaultLoansAPI } from "../../../src/";
+import { getAPITypes } from "../../../src/factory";
+import Big from "big.js";
+import { expect } from "chai";
+import { Kusama, Polkadot } from "@interlay/monetary-js";
+
+describe("DefaultLoansAPI", () => {
+    let api: ApiPromise;
+    let stubbedAssetRegistry: sinon.SinonStubbedInstance<DefaultAssetRegistryAPI>;
+    let loansApi: DefaultLoansAPI;
+
+    before(() => {
+        api = new ApiPromise();
+        // disconnect immediately to avoid printing errors
+        // we only need the instance to create variables
+        api.disconnect();
+        api.registerTypes(getAPITypes());
+    });
+
+    beforeEach(() => {
+        stubbedAssetRegistry = sinon.createStubInstance(DefaultAssetRegistryAPI);
+        loansApi = new DefaultLoansAPI(api, stubbedAssetRegistry);
+    });
+
+    describe("getCurrentBorrowBalance", () => {
+        it("should return a mocked currency amount", async () => {
+            const expectedCurrency = Kusama;
+            const expectedMockAmount = Big(4.2);
+
+            // pass in "null as never" as account as we know the mocked api doesn't use it.
+            const actualAmount = await loansApi.getCurrentBorrowBalance(null as never, Kusama);
+            expect(actualAmount.currency).to.eq(expectedCurrency);
+            expect(
+                actualAmount.toBig().eq(expectedMockAmount),
+                `Expected amount to be equal to ${expectedMockAmount.toString()}, but was ${actualAmount.toString()}`
+            ).to.be.true;
+        });
+    });
+
+    describe("getCurrentCollateralBalance", () => {
+        it("should return a mocked currency amount", async () => {
+            const expectedCurrency = Polkadot;
+            const expectedMockAmount = Big(12.34567);
+
+            // pass in "null as never" as account as we know the mocked api doesn't use it.
+            const actualAmount = await loansApi.getCurrentCollateralBalance(null as never, Polkadot);
+            expect(actualAmount.currency).to.eq(expectedCurrency);
+            expect(
+                actualAmount.toBig().eq(expectedMockAmount),
+                `Expected amount to be equal to ${expectedMockAmount.toString()}, but was ${actualAmount.toString()}`
+            ).to.be.true;
+        });
+    });
+});


### PR DESCRIPTION
new API: `LoansAPI` with two mocked methods as example.

Added unit tests that are currently meaningless. We can add tests when we add more realistic logic that need tests. For now, this is mostly just a placeholder to have it ready to go.