### PR TITLE
Feat: add coingecko id field to foreign asset

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@interlay/interbtc-api",
-  "version": "1.17.2",
+  "version": "1.17.3",
   "description": "JavaScript library to interact with interBTC and kBTC",
   "main": "build/src/index.js",
   "typings": "build/src/index.d.ts",

--- a/src/parachain/asset-registry.ts
+++ b/src/parachain/asset-registry.ts
@@ -56,9 +56,11 @@ export class DefaultAssetRegistryAPI implements AssetRegistryAPI {
     static metadataTupleToForeignAsset([key, metadata]: UnwrappedAssetRegistryMetadataTuple): ForeignAsset {
         const keyInner = storageKeyToNthInner<AssetId>(key);
         const currencyPart = DefaultAssetRegistryAPI.metadataToCurrency(metadata);
+        const coingeckoId = decodeBytesAsString(metadata.additional.coingeckoId);
 
         return {
             id: keyInner.toNumber(),
+            coingeckoId,
             ...currencyPart,
         };
     }
@@ -95,11 +97,13 @@ export class DefaultAssetRegistryAPI implements AssetRegistryAPI {
             return Promise.reject(new Error("Foreign asset not found"));
         }
         const currencyPart = DefaultAssetRegistryAPI.metadataToCurrency(optionMetadata.unwrap());
+        const coingeckoId = decodeBytesAsString(optionMetadata.unwrap().additional.coingeckoId);
 
         const numberId = id instanceof u32 ? id.toNumber() : id;
 
         return {
             id: numberId,
+            coingeckoId,
             ...currencyPart,
         };
     }

--- a/src/types/currency.ts
+++ b/src/types/currency.ts
@@ -37,7 +37,7 @@ export type CollateralIdLiteral =
 const CollateralCurrency = [Polkadot, Kusama, Interlay, Kintsugi] as const;
 type CollateralCurrency = typeof CollateralCurrency[number];
 
-export type ForeignAsset = Currency & { id: number };
+export type ForeignAsset = Currency & { id: number; coingeckoId: string };
 export type CollateralCurrencyExt = CollateralCurrency | ForeignAsset;
 export type CurrencyExt = Currency | ForeignAsset;
 

--- a/test/integration/parachain/staging/setup/initialize.test.ts
+++ b/test/integration/parachain/staging/setup/initialize.test.ts
@@ -208,6 +208,10 @@ describe("Initialize parachain state", () => {
                     symbol: api.createType("Bytes", AUSD_TICKER), // we will try to find it again in tests through this ticker
                     decimals: api.createType("u32", 6),
                     existentialDeposit: api.createType("u128", 1000),
+                    additional: api.createType("InterbtcPrimitivesCustomMetadata", {
+                        feePerSecond: api.createType("u128", 10),
+                        coingeckoId: api.createType("Bytes", "acala-dollar"),
+                    }),
                 },
                 api.createType("u32", nextAssetId)
             );

--- a/test/unit/parachain/asset-registry.test.ts
+++ b/test/unit/parachain/asset-registry.test.ts
@@ -24,6 +24,7 @@ describe("DefaultAssetRegistryAPI", () => {
         decimals: 8,
         existentialDeposit: 42,
         feesPerMinute: 15,
+        coingeckoId: "mock-coin-one",
     };
 
     before(() => {
@@ -44,6 +45,7 @@ describe("DefaultAssetRegistryAPI", () => {
             },
             InterbtcPrimitivesCustomMetadata: {
                 feePerSecond: "u128",
+                coingeckoId: "Bytes",
             },
         });
     });
@@ -59,6 +61,7 @@ describe("DefaultAssetRegistryAPI", () => {
             existentialDeposit: api.createType("u128", mockMetadataValues.existentialDeposit),
             additional: api.createType("InterbtcPrimitivesCustomMetadata", {
                 feePerSecond: api.createType("u128", mockMetadataValues.feesPerMinute),
+                coingeckoId: api.createType("Bytes", mockMetadataValues.coingeckoId),
             }),
         } as OrmlTraitsAssetRegistryAssetMetadata;
 
@@ -120,6 +123,11 @@ describe("DefaultAssetRegistryAPI", () => {
             expect(actual.decimals).to.equal(
                 mockMetadataValues.decimals,
                 `Expected currency base to be ${mockMetadataValues.decimals}, but was ${actual.decimals}`
+            );
+
+            expect(actual.coingeckoId).to.equal(
+                mockMetadataValues.coingeckoId,
+                `Expected coingecko id to be ${mockMetadataValues.coingeckoId}, but was ${actual.coingeckoId}`
             );
         });
     });


### PR DESCRIPTION
New field for ForeignAsset - coingeckoId: string

Beware that coingeckoId === "" if it is not set on the parachain's foreign asset entry.