### PR TITLE
fix: redeem expiry status

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@interlay/interbtc-api",
-  "version": "1.17.4",
+  "version": "1.17.5",
   "description": "JavaScript library to interact with interBTC and kBTC",
   "main": "build/src/index.js",
   "typings": "build/src/index.d.ts",

--- a/src/utils/encoding.ts
+++ b/src/utils/encoding.ts
@@ -283,7 +283,7 @@ export function parseRedeemRequestStatus(
     // now check if pending is actually expired
     const maxPeriod = Math.max(req.period.toNumber(), redeemPeriod);
     const openTime = req.opentime.toNumber();
-    if (openTime + maxPeriod > activeBlockCount) {
+    if (openTime + maxPeriod <= activeBlockCount) {
         return RedeemStatus.Expired;
     }
 

--- a/src/utils/encoding.ts
+++ b/src/utils/encoding.ts
@@ -283,7 +283,7 @@ export function parseRedeemRequestStatus(
     // now check if pending is actually expired
     const maxPeriod = Math.max(req.period.toNumber(), redeemPeriod);
     const openTime = req.opentime.toNumber();
-    if (openTime + maxPeriod <= activeBlockCount) {
+    if (openTime + maxPeriod < activeBlockCount) {
         return RedeemStatus.Expired;
     }
 

--- a/test/unit/utils/encoding.test.ts
+++ b/test/unit/utils/encoding.test.ts
@@ -1,8 +1,19 @@
 import { TypeRegistry } from "@polkadot/types";
 import { assert } from "../../chai";
 import { getAPITypes } from "../../../src/factory";
-import { reverseEndianness, uint8ArrayToString, stripHexPrefix, reverseEndiannessHex } from "../../../src/utils";
+import { RedeemStatus } from "../../../src/types";
+import {
+    reverseEndianness,
+    uint8ArrayToString,
+    stripHexPrefix,
+    reverseEndiannessHex,
+    parseRedeemRequestStatus,
+} from "../../../src/utils";
 import { H256Le } from "../../../src/interfaces/default";
+import {
+    InterbtcPrimitivesRedeemRedeemRequest,
+    InterbtcPrimitivesRedeemRedeemRequestStatus,
+} from "@polkadot/types/lookup";
 
 describe("Encoding", () => {
     let registry: TypeRegistry;
@@ -42,5 +53,119 @@ describe("Encoding", () => {
         const blockHashHexLE = "0x9067166e896765258f6636a082abad6953f17a0e8dc21fc4f85648ceeedbda69";
         const blockHashHexBE = "0x69dadbeece4856f8c41fc28d0e7af15369adab82a036668f256567896e166790";
         return assert.equal(reverseEndiannessHex(blockHashHexLE), stripHexPrefix(blockHashHexBE));
+    });
+
+    describe("parseRedeemRequestStatus", () => {
+        const buildMockStatus = (status: "Pending" | "Completed" | "Reimbursed" | "Retried") =>
+            <InterbtcPrimitivesRedeemRedeemRequestStatus>{
+                isPending: status === "Pending",
+                isCompleted: status === "Completed",
+                isReimbursed: status === "Reimbursed",
+                isRetried: status === "Retried",
+                type: status,
+            };
+
+        const buildMockRedeemRequest = (
+            status: InterbtcPrimitivesRedeemRedeemRequestStatus,
+            opentime?: number,
+            period?: number
+        ) => {
+            return <InterbtcPrimitivesRedeemRedeemRequest>{
+                period: registry.createType("u32", period),
+                opentime: registry.createType("u32", opentime),
+                status: status,
+            };
+        };
+
+        const assertEqualPretty = (expected: RedeemStatus, actual: RedeemStatus): void => {
+            assert.equal(actual, expected, `Expected '${RedeemStatus[expected]}' but was '${RedeemStatus[actual]}'`);
+        };
+
+        it("should correctly parse completed status", () => {
+            const mockRequest = buildMockRedeemRequest(buildMockStatus("Completed"));
+            const expectedStatus = RedeemStatus.Completed;
+
+            const actualStatus = parseRedeemRequestStatus(mockRequest, 42, 42);
+
+            assertEqualPretty(actualStatus, expectedStatus);
+        });
+
+        it("should correctly parse reimbursed status", () => {
+            const mockRequest = buildMockRedeemRequest(buildMockStatus("Reimbursed"));
+            const expectedStatus = RedeemStatus.Reimbursed;
+
+            const actualStatus = parseRedeemRequestStatus(mockRequest, 42, 42);
+
+            assertEqualPretty(actualStatus, expectedStatus);
+        });
+
+        it("should correctly parse retried status", () => {
+            const mockRequest = buildMockRedeemRequest(buildMockStatus("Retried"));
+            const expectedStatus = RedeemStatus.Retried;
+
+            const actualStatus = parseRedeemRequestStatus(mockRequest, 42, 42);
+
+            assertEqualPretty(actualStatus, expectedStatus);
+        });
+
+        describe("should correctly parse expired status", () => {
+            const currentBlock = 42;
+            const opentimeBlock = 1;
+            // pending status internally, but expect expired due to blocks elapsed
+            const mockInternalPendingStatus = buildMockStatus("Pending");
+            it("when global redeem period is larger than request period", () => {
+                const globalRedeemPeriod = 30;
+                const requestPeriod = 25;
+
+                const mockRequest = buildMockRedeemRequest(mockInternalPendingStatus, opentimeBlock, requestPeriod);
+                const expectedStatus = RedeemStatus.Expired;
+
+                const actualStatus = parseRedeemRequestStatus(mockRequest, globalRedeemPeriod, currentBlock);
+
+                assertEqualPretty(actualStatus, expectedStatus);
+            });
+
+            it("when global redeem period is smaller than request period", () => {
+                const globalRedeemPeriod = 25;
+                const requestPeriod = 30;
+
+                // pending status internally, but expect expired due to blocks elapsed
+                const mockRequest = buildMockRedeemRequest(mockInternalPendingStatus, opentimeBlock, requestPeriod);
+                const expectedStatus = RedeemStatus.Expired;
+
+                const actualStatus = parseRedeemRequestStatus(mockRequest, globalRedeemPeriod, currentBlock);
+
+                assertEqualPretty(actualStatus, expectedStatus);
+            });
+
+            it("when opentime + period is equal to current block", () => {
+                const globalRedeemPeriod = currentBlock - opentimeBlock;
+                // anything less than above
+                const requestPeriod = globalRedeemPeriod - 1;
+
+                // pending status internally, but expect expired due to blocks elapsed
+                const mockRequest = buildMockRedeemRequest(mockInternalPendingStatus, opentimeBlock, requestPeriod);
+                const expectedStatus = RedeemStatus.Expired;
+
+                const actualStatus = parseRedeemRequestStatus(mockRequest, globalRedeemPeriod, currentBlock);
+
+                assertEqualPretty(actualStatus, expectedStatus);
+            });
+        });
+
+        it("should correctly parse pending status", () => {
+            const currentBlock = 42;
+            const opentimeBlock = 1;
+            const globalRedeemPeriod = 50;
+            const requestPeriod = 25;
+
+            // pending status internally, and expect still pending due to blocks elapsed
+            const mockRequest = buildMockRedeemRequest(buildMockStatus("Pending"), opentimeBlock, requestPeriod);
+            const expectedStatus = RedeemStatus.PendingWithBtcTxNotFound;
+
+            const actualStatus = parseRedeemRequestStatus(mockRequest, globalRedeemPeriod, currentBlock);
+
+            assertEqualPretty(actualStatus, expectedStatus);
+        });
     });
 });


### PR DESCRIPTION
Fix a bug where the utility method `parseRedeemRequestStatus` returns a pending status when it should return expired and vice versa.