### PR TITLE
Chore: Use nomination pallet for deposit/withdraw collateral extrinsics

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@interlay/interbtc-api",
-  "version": "1.19.0",
+  "version": "1.20.0",
   "description": "JavaScript library to interact with interBTC and kBTC",
   "main": "build/src/index.js",
   "typings": "build/src/index.d.ts",

--- a/src/parachain/vaults.ts
+++ b/src/parachain/vaults.ts
@@ -21,6 +21,7 @@ import {
     addHexPrefix,
     currencyIdToMonetaryCurrency,
     decodeRpcVaultId,
+    addressOrPairAsAccountId,
 } from "../utils";
 import { TokensAPI } from "./tokens";
 import { OracleAPI } from "./oracle";
@@ -38,7 +39,7 @@ import {
 } from "../types";
 import { RewardsAPI } from "./rewards";
 import { UnsignedFixedPoint } from "../interfaces";
-import { AssetRegistryAPI, SystemAPI, LoansAPI } from "./index";
+import { AssetRegistryAPI, SystemAPI, LoansAPI, DefaultNominationAPI } from "./index";
 import { ApiTypes, AugmentedEvent, SubmittableExtrinsic } from "@polkadot/api/types";
 import { ISubmittableResult, AnyTuple } from "@polkadot/types/types";
 
@@ -222,11 +223,11 @@ export interface VaultsAPI {
      * Build withdraw collateral extrinsic (transaction) without sending it.
      *
      * @param amount The amount of collateral to withdraw
-     * @returns A withdraw collateral submittable extrinsic.
+     * @returns A withdraw collateral submittable extrinsic as promise.
      */
     buildWithdrawCollateralExtrinsic(
         amount: MonetaryAmount<CollateralCurrencyExt>
-    ): SubmittableExtrinsic<"promise", ISubmittableResult>;
+    ): Promise<SubmittableExtrinsic<"promise", ISubmittableResult>>;
 
     /**
      * @param amount The amount of collateral to withdraw
@@ -478,25 +479,44 @@ export class DefaultVaultsAPI implements VaultsAPI {
         ]);
     }
 
-    buildWithdrawCollateralExtrinsic(
+    async buildWithdrawCollateralExtrinsic(
         amount: MonetaryAmount<CollateralCurrencyExt>
-    ): SubmittableExtrinsic<"promise", ISubmittableResult> {
-        const amountAtomicUnit = this.api.createType("Balance", amount.toString(true));
-        const currencyPair = newVaultCurrencyPair(this.api, amount.currency, this.wrappedCurrency);
-        return this.api.tx.vaultRegistry.withdrawCollateral(currencyPair, amountAtomicUnit);
+    ): Promise<SubmittableExtrinsic<"promise", ISubmittableResult>> {
+        const account = this.transactionAPI.getAccount();
+        if (account == undefined) {
+            throw new Error("Account must be connected to create a collateral withdrawal request.");
+        }
+        const vaultAccountId = addressOrPairAsAccountId(this.api, account);
+
+        return await DefaultNominationAPI.buildWithdrawCollateralExtrinsic(
+            this.api,
+            this.rewardsAPI,
+            vaultAccountId,
+            amount,
+            this.wrappedCurrency
+        );
     }
 
     async withdrawCollateral(amount: MonetaryAmount<CollateralCurrencyExt>): Promise<void> {
-        const tx = this.buildWithdrawCollateralExtrinsic(amount);
+        const tx = await this.buildWithdrawCollateralExtrinsic(amount);
         await this.transactionAPI.sendLogged(tx, this.api.events.vaultRegistry.WithdrawCollateral, true);
     }
 
     buildDepositCollateralExtrinsic(
         amount: MonetaryAmount<CollateralCurrencyExt>
     ): SubmittableExtrinsic<"promise", ISubmittableResult> {
-        const amountAtomicUnit = this.api.createType("Balance", amount.toString(true));
-        const currencyPair = newVaultCurrencyPair(this.api, amount.currency, this.wrappedCurrency);
-        return this.api.tx.vaultRegistry.depositCollateral(currencyPair, amountAtomicUnit);
+        const account = this.transactionAPI.getAccount();
+        if (account == undefined) {
+            throw new Error("Account must be connected to create a collateral deposit request.");
+        }
+        const vaultAccountId = addressOrPairAsAccountId(this.api, account);
+
+        return DefaultNominationAPI.buildDepositCollateralExtrinsic(
+            this.api,
+            vaultAccountId,
+            amount,
+            this.wrappedCurrency
+        );
     }
 
     async depositCollateral(amount: MonetaryAmount<CollateralCurrencyExt>): Promise<void> {
@@ -545,7 +565,9 @@ export class DefaultVaultsAPI implements VaultsAPI {
         );
     }
 
-    async getMinimumCollateral(collateralCurrency: CollateralCurrencyExt): Promise<MonetaryAmount<CollateralCurrencyExt>> {
+    async getMinimumCollateral(
+        collateralCurrency: CollateralCurrencyExt
+    ): Promise<MonetaryAmount<CollateralCurrencyExt>> {
         const collateralCurrencyId = newCurrencyId(this.api, collateralCurrency);
         const minimumCollateral = await this.api.query.vaultRegistry.minimumCollateralVault(collateralCurrencyId);
 
@@ -846,7 +868,11 @@ export class DefaultVaultsAPI implements VaultsAPI {
             currencies: vaultId.currencies,
         });
         const wrappedCurrencyPrimitive = newCurrencyId(this.api, this.getWrappedCurrency());
-        const currency = await currencyIdToMonetaryCurrency(this.assetRegistryAPI, this.loansAPI, wrappedCurrencyPrimitive);
+        const currency = await currencyIdToMonetaryCurrency(
+            this.assetRegistryAPI,
+            this.loansAPI,
+            wrappedCurrencyPrimitive
+        );
         const amount = newMonetaryAmount(balance.amount.toString(), currency);
         return amount;
     }
@@ -879,7 +905,12 @@ export class DefaultVaultsAPI implements VaultsAPI {
         for (const [vaultId, balanceWrapper] of premiumRedeemVaults) {
             const amount = newMonetaryAmount(balanceWrapper.amount.toString(), this.getWrappedCurrency());
 
-            const ibtcPrimitivesVaultId = await decodeRpcVaultId(this.api, this.assetRegistryAPI, this.loansAPI, vaultId);
+            const ibtcPrimitivesVaultId = await decodeRpcVaultId(
+                this.api,
+                this.assetRegistryAPI,
+                this.loansAPI,
+                vaultId
+            );
             map.set(ibtcPrimitivesVaultId, amount);
         }
         return map;
@@ -891,7 +922,12 @@ export class DefaultVaultsAPI implements VaultsAPI {
         for (const [vaultId, balanceWrapper] of issuableVaults) {
             const amount = newMonetaryAmount(balanceWrapper.amount.toString(), this.getWrappedCurrency());
 
-            const ibtcPrimitivesVaultId = await decodeRpcVaultId(this.api, this.assetRegistryAPI, this.loansAPI, vaultId);
+            const ibtcPrimitivesVaultId = await decodeRpcVaultId(
+                this.api,
+                this.assetRegistryAPI,
+                this.loansAPI,
+                vaultId
+            );
             vaultIdsToAmountsMap.set(ibtcPrimitivesVaultId, amount);
         }
 

--- a/src/utils/encoding.ts
+++ b/src/utils/encoding.ts
@@ -35,6 +35,7 @@ import { BalanceWrapper, SignedFixedPoint, UnsignedFixedPoint, VaultId } from ".
 import { CollateralCurrencyExt, CurrencyExt, WrappedCurrency } from "../types";
 import { newMonetaryAmount } from "../utils";
 import { AssetRegistryAPI, LoansAPI, VaultsAPI } from "../parachain";
+import { AddressOrPair } from "@polkadot/api/types";
 
 /**
  * Converts endianness of a Uint8Array
@@ -221,6 +222,25 @@ export function newBalanceWrapper(api: ApiPromise, atomicAmount: BigSource): Bal
     return api.createType("BalanceWrapper", {
         amount: api.createType("Text", Big(atomicAmount).toString()),
     });
+}
+
+export function addressOrPairAsAccountId(api: ApiPromise, addyOrpair: AddressOrPair): AccountId {
+    // need to explicitly try and figure out which type this is, so cast to any
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const input = addyOrpair as any;
+
+    // a string is a string is a string
+    if (typeof input === "string") {
+        return newAccountId(api, input);
+    }
+
+    // keyring pair has .address field as string
+    if (typeof input.address === "string") {
+        return newAccountId(api, input.address);
+    }
+
+    // AccountId and Account will have .toString() methods, try those
+    return newAccountId(api, input.toString());
 }
 
 export async function parseReplaceRequest(


### PR DESCRIPTION
❗ Breaking change ❗ 

Api signature change for `VaultsApi.buildWithdrawCollateralExtrinsic`: now `async` and returning a `Promise`
