### PR TITLE
refactor(loans): remove read from AccountEarned storage

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@interlay/interbtc-api",
-  "version": "1.20.0",
+  "version": "1.20.1",
   "description": "JavaScript library to interact with interBTC and kBTC",
   "main": "build/src/index.js",
   "typings": "build/src/index.d.ts",

--- a/src/types/loans.ts
+++ b/src/types/loans.ts
@@ -9,7 +9,6 @@ interface LoanPosition {
 
 interface LendPosition extends LoanPosition {
     isCollateral: boolean;
-    earnedInterest: MonetaryAmount<CurrencyExt>;
 }
 
 interface BorrowPosition extends LoanPosition {

--- a/test/integration/parachain/staging/sequential/loans.test.ts
+++ b/test/integration/parachain/staging/sequential/loans.test.ts
@@ -191,10 +191,6 @@ describe("Loans", () => {
             expect(lendPosition.amount.toString()).to.be.equal(lendAmount.toString());
             expect(lendPosition.currency).to.be.equal(underlyingCurrency);
             expect(lendPosition.isCollateral).to.be.false;
-
-            // No interest reward because no one borrowed yet.
-            expect(lendPosition.earnedInterest.toBig().eq(0)).to.be.true;
-
             // TODO: add tests for more markets
         });
         it("should get correct data after position is enabled as collateral", async function () {
@@ -252,11 +248,6 @@ describe("Loans", () => {
             ]);
             expect(sudoEventFound, `Sudo event to manipulate time not found - timed out after ${approx10Blocks} ms`).to
                 .be.true;
-
-            const [lendPosition] = await userInterBtcAPI.loans.getLendPositionsOfAccount(userAccountId);
-
-            // test printing out to see earned Interest value
-            console.log(lendPosition.earnedInterest.toHuman());
         });
     });
 


### PR DESCRIPTION
Removing `earnedInterest` field from `LendPosition` because `AccountEarned` storage field is being removed from runtime.

[Context](https://discord.com/channels/745259537707040778/1063145456756064256/1063145460509974568)