### PR TITLE
chore: script to create proposals

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "xcm-cross-chain-transfer": "ts-node scripts/xcm-cross-chain-transfer",
     "xcm-return-unknown-tokens": "ts-node scripts/xcm-return-unknown-tokens",
     "democracy": "ts-node scripts/democracy",
+    "create-proposal": "ts-node scripts/create-proposal",
     "test": "run-s build test:*",
     "test:lint": "eslint src --ext .ts",
     "test:unit": "mocha test/unit/*.test.ts test/unit/**/*.test.ts",

--- a/scripts/create-proposal.ts
+++ b/scripts/create-proposal.ts
@@ -1,0 +1,58 @@
+/* eslint @typescript-eslint/no-var-requires: "off" */
+import { createSubstrateAPI } from "../src/factory";
+import { ApiPromise, Keyring } from "@polkadot/api";
+import { DefaultTransactionAPI } from "../src/parachain";
+import { cryptoWaitReady } from "@polkadot/util-crypto";
+import { XcmVersionedMultiLocation } from "@polkadot/types/lookup";
+
+import { SubmittableExtrinsic } from "@polkadot/api/types";
+import { assert } from "console";
+
+import { Arguments } from 'yargs';
+import { url } from "inspector";
+
+const yargs = require("yargs/yargs");
+const { hideBin } = require("yargs/helpers");
+const args = yargs(hideBin(process.argv))
+    .option("url", {
+        type: "string",
+        description: "Polkadotjs url",
+        demandOption: true,
+    })
+    .argv;
+
+
+main().catch((err) => {
+    console.log("Error thrown by script:");
+    console.log(err);
+});
+
+async function main(): Promise<void> {
+    const url = new URL(args['url']);
+    const rpc = url.searchParams.get('rpc');
+    const hashPrefix = '#/extrinsics/decode/';
+    const extrinsic = url.hash.replace(hashPrefix, '');
+    console.log("rpc:", rpc);
+    console.log("extrinsic:", extrinsic);
+
+    const api = await createSubstrateAPI(rpc as string);
+    const call = api.createType('Call', extrinsic);
+    console.log('Full input tx: ', call.toHuman());
+    console.log('');
+    console.log('Abbreviated input tx: ', call.section.toString() + '.' + call.method.toString());
+    console.log('');
+
+    const deposit = api.consts.democracy.minimumDeposit.toNumber();
+    const preImageSubmission = api.tx.democracy.notePreimage(call.toHex());
+    const proposal = api.tx.democracy.propose(call.hash.toHex(), deposit);
+    const batched = api.tx.utility.batchAll([preImageSubmission, proposal]);
+
+    console.log('**Extrinsic:**', url.href);
+    console.log('');
+
+    url.hash = hashPrefix + batched.toHex();
+    console.log('**Proposal:**', url.href);
+    console.log('');
+
+    await api.disconnect();
+}


### PR DESCRIPTION
Example usage: 
```
❯ yarn create-proposal --url 'https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fapi-kusama.interlay.io%2Fparachain#/extrinsics/decode/0x18000c00000010734b534d10534b534d0000000000000000000000000000000001010103009520040605a10f7f269e903000000000000000000000000000'
```

Output: 
```
Abbreviated input tx:  assetRegistry.registerAsset

**Extrinsic:** https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fapi-kusama.interlay.io%2Fparachain#/extrinsics/decode/0x18000c00000010734b534d10534b534d0000000000000000000000000000000001010103009520040605a10f7f269e903000000000000000000000000000

**Proposal:** https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fapi-kusama.interlay.io%2Fparachain#/extrinsics/decode/0xb90104020208460af818000c00000010734b534d10534b534d0000000000000000000000000000000001010103009520040605a10f7f269e903000000000000000000000000000460003bad0363b23ab3bf9a222a20ce40f448f7c5c0224cc23374e30575f5ff0fc890b005039278c04
```

This automatically detects the used parachain wss connection, and creates a submittable extrinsic to be submitted on that same parachain. The deposit amounts are fetched from on-chain so this works for both kintsugi and interlay. This makes it a little bit less of a chore to create proposals for extrinsics, and a little bit less error-prone