### PR TITLE
fix: round up lending debt

### DIFF
--- a/src/parachain/loans.ts
+++ b/src/parachain/loans.ts
@@ -3,7 +3,7 @@ import { MonetaryAmount } from "@interlay/monetary-js";
 import { BorrowPosition, CurrencyExt, LoanAsset, LendPosition, TickerToData, LendToken, LoanPosition } from "../types";
 import { AssetRegistryAPI } from "./asset-registry";
 import { ApiPromise } from "@polkadot/api";
-import Big from "big.js";
+import Big, { RoundingMode } from "big.js";
 import {
     currencyIdToMonetaryCurrency,
     decodeFixedPointType,
@@ -302,7 +302,7 @@ export class DefaultLoansAPI implements LoansAPI {
         // @note Formula for computing total debt: https://docs.parallel.fi/parallel-finance/#2.6-interest-rate-index
         // To compute only earned debt, subtract 1 from factor
         const factor = currentBorrowIndex.div(snapshotBorrowIndex).sub(1);
-        return borrowedAmount.mul(factor);
+        return borrowedAmount.mul(factor).round(0, RoundingMode.RoundUp);
     }
 
     async _getBorrowPosition(


### PR DESCRIPTION
We need to round up, as is done in the parachain: https://github.com/interlay/interbtc/blob/master/crates/loans/src/lib.rs#L1546-L1559

This was changed in https://github.com/interlay/interbtc/pull/896 since rounding down led to possibly free loans. This PR should fix the [open ticket in notion](https://www.notion.so/interlay/Borrow-interest-incorrect-0e9867b36d384361b791970cd8e5d6f6)