### PR TITLE
feat(loans): get undercollateralized borrowers

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   "engineStrict": true,
   "dependencies": {
     "@interlay/esplora-btc-api": "0.4.0",
-    "@interlay/interbtc-types": "1.11.1",
+    "@interlay/interbtc-types": "1.11.2",
     "@interlay/monetary-js": "0.7.0",
     "@polkadot/api": "9.11.1",
     "big.js": "6.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@interlay/interbtc-api",
-  "version": "1.20.3",
+  "version": "1.21.0",
   "description": "JavaScript library to interact with interBTC and kBTC",
   "main": "build/src/index.js",
   "typings": "build/src/index.d.ts",

--- a/src/interbtc-api.ts
+++ b/src/interbtc-api.ts
@@ -105,7 +105,7 @@ export class DefaultInterBtcApi implements InterBtcApi {
         this.transactionAPI = new DefaultTransactionAPI(api, _account);
 
         this.assetRegistry = new DefaultAssetRegistryAPI(api);
-        this.loans = new DefaultLoansAPI(api, this.assetRegistry, this.transactionAPI);
+        this.loans = new DefaultLoansAPI(api, wrappedCurrency, this.assetRegistry, this.transactionAPI);
         this.tokens = new DefaultTokensAPI(api, this.transactionAPI);
         this.system = new DefaultSystemAPI(api, this.transactionAPI);
         this.oracle = new DefaultOracleAPI(api, wrappedCurrency, this.transactionAPI);

--- a/src/parachain/loans.ts
+++ b/src/parachain/loans.ts
@@ -183,8 +183,9 @@ export interface LoansAPI {
         collateralCurrency: CurrencyExt
     ): Promise<void>;
     /**
-     * @returns An array of `[AccountId, Shortage]` tuples, where `Shortage` is expressed in the
-     * wrapped currency
+     * @returns An array of `UndercollateralizedPosition`s, with all details needed to
+     * liquidate them (accountId, shortfall - expressed in the wrapped currency, open borrow positions, collateral
+     * deposits).
      */
     getUndercollateralizedBorrowers(): Promise<Array<UndercollateralizedPosition>>;
     /**
@@ -192,6 +193,11 @@ export interface LoansAPI {
      * This includes accounts with zero outstanding debt.
      */
     getBorrowerAccountIds(): Promise<Array<AccountId>>;
+    /**
+     * @param accountId The account whose liquidity to query from the chain
+     * @returns An `AccountLiquidity` object, which is valid even for accounts that didn't use the loans pallet at all
+     */
+    getLiquidationThresholdLiquidity(accountId: AccountId): Promise<AccountLiquidity>;
 }
 
 export class DefaultLoansAPI implements LoansAPI {

--- a/src/parachain/nomination.ts
+++ b/src/parachain/nomination.ts
@@ -281,7 +281,6 @@ export class DefaultNominationAPI implements NominationAPI {
             rawList.map(async (rawNomination): Promise<NominationReward> => {
                 const reward = await this.vaultsAPI.computeReward(
                     rawNomination.vaultId.accountId,
-                    rawNomination.nominatorId,
                     await currencyIdToMonetaryCurrency(
                         this.assetRegistryAPI,
                         this.loansAPI,
@@ -314,9 +313,8 @@ export class DefaultNominationAPI implements NominationAPI {
         vaultId: AccountId,
         collateralCurrency: CollateralCurrencyExt,
         rewardCurrency: Currency,
-        nominatorId: AccountId
     ): Promise<MonetaryAmount<Currency>> {
-        return await this.vaultsAPI.computeReward(vaultId, nominatorId, collateralCurrency, rewardCurrency);
+        return await this.vaultsAPI.computeReward(vaultId, collateralCurrency, rewardCurrency);
     }
 
     async list(): Promise<Nomination[]> {

--- a/src/types/loans.ts
+++ b/src/types/loans.ts
@@ -38,6 +38,15 @@ interface LoanMarket {
     lendTokenId: number;
 }
 
+/**
+ * The liquidity status of an account, based on the value of its collateral and loans.
+ * * `liquidity` is `max(totalCollateralValueAsWrapped - totalBorrowedValueAsWrapped, 0)`, where each
+ * item in the `totalCollateralValueAsWrapped` sum is first scaled down by the collateralization
+ * required by that market (e.g `100 satoshi * 0.75 + 150 satoshi * 0.8`, where `0.75` and `0.8`
+ * are the collateralization thresholds).
+ * * `shortfall` is very similar to liquidity: `max(totalBorrowedValueAsWrapped - totalCollateralValueAsWrapped, 0)`
+ * so it is only positive when the total borrowed amount exceeds what the collateral can cover.
+ */
 type AccountLiquidity = {
     liquidity: MonetaryAmount<WrappedCurrency>;
     shortfall: MonetaryAmount<WrappedCurrency>;

--- a/src/types/loans.ts
+++ b/src/types/loans.ts
@@ -3,11 +3,10 @@ import Big from "big.js";
 import { CurrencyExt, WrappedCurrency } from "./currency";
 
 interface LoanPosition {
-    currency: CurrencyExt;
     amount: MonetaryAmount<CurrencyExt>;
 }
 
-interface LendPosition extends LoanPosition {
+interface CollateralPosition extends LoanPosition {
     isCollateral: boolean;
 }
 
@@ -43,4 +42,10 @@ type AccountLiquidity = {
     shortfall: MonetaryAmount<WrappedCurrency>;
 };
 
-export type { LoanPosition, LendPosition, BorrowPosition, LoanAsset, TickerToData, LoanMarket, AccountLiquidity };
+type UndercollateralizedPosition = {
+    shortfall: MonetaryAmount<WrappedCurrency>;
+    collateralPositions: Array<LoanPosition>,
+    borrowPositions: Array<BorrowPosition>,
+}
+
+export type { LoanPosition, CollateralPosition, BorrowPosition, LoanAsset, TickerToData, LoanMarket, AccountLiquidity };

--- a/src/types/loans.ts
+++ b/src/types/loans.ts
@@ -1,4 +1,5 @@
 import { MonetaryAmount } from "@interlay/monetary-js";
+import { AccountId } from "@polkadot/types/interfaces";
 import Big from "big.js";
 import { CurrencyExt, WrappedCurrency } from "./currency";
 
@@ -43,9 +44,19 @@ type AccountLiquidity = {
 };
 
 type UndercollateralizedPosition = {
+    accountId: AccountId;
     shortfall: MonetaryAmount<WrappedCurrency>;
-    collateralPositions: Array<LoanPosition>,
-    borrowPositions: Array<BorrowPosition>,
-}
+    collateralPositions: Array<LoanPosition>;
+    borrowPositions: Array<BorrowPosition>;
+};
 
-export type { LoanPosition, CollateralPosition, BorrowPosition, LoanAsset, TickerToData, LoanMarket, AccountLiquidity };
+export type {
+    LoanPosition,
+    CollateralPosition,
+    BorrowPosition,
+    LoanAsset,
+    TickerToData,
+    LoanMarket,
+    AccountLiquidity,
+    UndercollateralizedPosition,
+};

--- a/src/types/loans.ts
+++ b/src/types/loans.ts
@@ -1,6 +1,6 @@
 import { MonetaryAmount } from "@interlay/monetary-js";
 import Big from "big.js";
-import { CurrencyExt } from "./currency";
+import { CurrencyExt, WrappedCurrency } from "./currency";
 
 interface LoanPosition {
     currency: CurrencyExt;
@@ -38,4 +38,9 @@ interface LoanMarket {
     lendTokenId: number;
 }
 
-export type { LoanPosition, LendPosition, BorrowPosition, LoanAsset, TickerToData, LoanMarket };
+type AccountLiquidity = {
+    liquidity: MonetaryAmount<WrappedCurrency>;
+    shortfall: MonetaryAmount<WrappedCurrency>;
+};
+
+export type { LoanPosition, LendPosition, BorrowPosition, LoanAsset, TickerToData, LoanMarket, AccountLiquidity };

--- a/test/integration/parachain/release/redeem.test.ts
+++ b/test/integration/parachain/release/redeem.test.ts
@@ -74,11 +74,11 @@ describe("redeem", () => {
         const transactionAPI = new DefaultTransactionAPI(api);
         assetRegistry = new DefaultAssetRegistryAPI(api);
         userInterBtcAPI = new DefaultInterBtcApi(api, "regtest", userAccount, ESPLORA_BASE_PATH);
-        loansAPI = new DefaultLoansAPI(api, assetRegistry, transactionAPI);
+        wrappedCurrency = userInterBtcAPI.getWrappedCurrency();
+        loansAPI = new DefaultLoansAPI(api, wrappedCurrency, assetRegistry, transactionAPI);
         oracleInterBtcAPI = new DefaultInterBtcApi(api, "regtest", oracleAccount, ESPLORA_BASE_PATH);
         reporterInterBtcAPI = new DefaultInterBtcApi(api, "regtest", reportingVaultAccount, ESPLORA_BASE_PATH);
         collateralCurrencies = getCorrespondingCollateralCurrenciesForTests(userInterBtcAPI.getGovernanceCurrency());
-        wrappedCurrency = userInterBtcAPI.getWrappedCurrency();
         vaultToLiquidate = keyring.addFromUri(VAULT_TO_LIQUIDATE_URI);
         vaultToLiquidateIds = collateralCurrencies.map((collateralCurrency) =>
             newVaultId(api, vaultToLiquidate.address, collateralCurrency, wrappedCurrency)

--- a/test/integration/parachain/staging/sequential/loans.test.ts
+++ b/test/integration/parachain/staging/sequential/loans.test.ts
@@ -190,7 +190,7 @@ describe("Loans", () => {
             const [lendPosition] = await userInterBtcAPI.loans.getLendPositionsOfAccount(userAccountId);
 
             expect(lendPosition.amount.toString()).to.be.equal(lendAmount.toString());
-            expect(lendPosition.currency).to.be.equal(underlyingCurrency);
+            expect(lendPosition.amount.currency).to.be.equal(underlyingCurrency);
             expect(lendPosition.isCollateral).to.be.false;
             // TODO: add tests for more markets
         });

--- a/test/integration/parachain/staging/sequential/nomination.test.ts
+++ b/test/integration/parachain/staging/sequential/nomination.test.ts
@@ -67,9 +67,9 @@ describe.skip("NominationAPI", () => {
         userInterBtcAPI = new DefaultInterBtcApi(api, "regtest", userAccount, ESPLORA_BASE_PATH);
         sudoInterBtcAPI = new DefaultInterBtcApi(api, "regtest", sudoAccount, ESPLORA_BASE_PATH);
         assetRegistry = new DefaultAssetRegistryAPI(api);
-        loansAPI = new DefaultLoansAPI(api, assetRegistry, transactionAPI);
-        collateralCurrencies = getCorrespondingCollateralCurrenciesForTests(userInterBtcAPI.getGovernanceCurrency());
         wrappedCurrency = userInterBtcAPI.getWrappedCurrency();
+        loansAPI = new DefaultLoansAPI(api, wrappedCurrency, assetRegistry, transactionAPI);
+        collateralCurrencies = getCorrespondingCollateralCurrenciesForTests(userInterBtcAPI.getGovernanceCurrency());
         vault_1 = keyring.addFromUri(VAULT_1_URI);
         vault_1_ids = collateralCurrencies.map((collateralCurrency) =>
             newVaultId(api, vault_1.address, collateralCurrency, wrappedCurrency)

--- a/test/integration/parachain/staging/sequential/redeem.test.ts
+++ b/test/integration/parachain/staging/sequential/redeem.test.ts
@@ -74,10 +74,10 @@ describe("redeem", () => {
         userAccount = keyring.addFromUri(USER_1_URI);
         interBtcAPI = new DefaultInterBtcApi(api, "regtest", userAccount, ESPLORA_BASE_PATH);
         assetRegistry = new DefaultAssetRegistryAPI(api);
-        loansAPI = new DefaultLoansAPI(api, assetRegistry, transactionAPI);
+        wrappedCurrency = interBtcAPI.getWrappedCurrency();
+        loansAPI = new DefaultLoansAPI(api, wrappedCurrency, assetRegistry, transactionAPI);
 
         const collateralCurrencies = getCorrespondingCollateralCurrenciesForTests(interBtcAPI.getGovernanceCurrency());
-        wrappedCurrency = interBtcAPI.getWrappedCurrency();
         vault_1 = keyring.addFromUri(VAULT_1_URI);
         vault_2 = keyring.addFromUri(VAULT_2_URI);
 

--- a/test/integration/parachain/staging/sequential/replace.test.ts
+++ b/test/integration/parachain/staging/sequential/replace.test.ts
@@ -64,8 +64,8 @@ describe("replace", () => {
         userAccount = keyring.addFromUri(USER_1_URI);
         assetRegistry = new DefaultAssetRegistryAPI(api);
         interBtcAPI = new DefaultInterBtcApi(api, "regtest", userAccount, ESPLORA_BASE_PATH);
-        loansAPI = new DefaultLoansAPI(api, assetRegistry, transactionAPI);
         wrappedCurrency = interBtcAPI.getWrappedCurrency();
+        loansAPI = new DefaultLoansAPI(api, wrappedCurrency, assetRegistry, transactionAPI);
         const collateralCurrencies = getCorrespondingCollateralCurrenciesForTests(interBtcAPI.getGovernanceCurrency());
         vault_3 = keyring.addFromUri(VAULT_3_URI);
         vault_3_ids = collateralCurrencies.map((collateralCurrency) =>

--- a/test/integration/parachain/staging/sequential/vaults.test.ts
+++ b/test/integration/parachain/staging/sequential/vaults.test.ts
@@ -63,7 +63,7 @@ describe("vaultsAPI", () => {
 
         wrappedCurrency = interBtcAPI.getWrappedCurrency();
         governanceCurrency = interBtcAPI.getGovernanceCurrency();
-        loansAPI = new DefaultLoansAPI(api, assetRegistry, transactionAPI);
+        loansAPI = new DefaultLoansAPI(api, wrappedCurrency, assetRegistry, transactionAPI);
 
         collateralCurrencies = getCorrespondingCollateralCurrenciesForTests(governanceCurrency);
         const aUSD = await getAUSDForeignAsset(assetRegistry);

--- a/test/unit/parachain/loans.test.ts
+++ b/test/unit/parachain/loans.test.ts
@@ -10,7 +10,7 @@ import {
 import { getAPITypes } from "../../../src/factory";
 import Big from "big.js";
 import { expect } from "chai";
-import { Interlay, MonetaryAmount, Polkadot } from "@interlay/monetary-js";
+import { Interlay, KBtc, MonetaryAmount, Polkadot } from "@interlay/monetary-js";
 
 describe("DefaultLoansAPI", () => {
     let api: ApiPromise;
@@ -29,7 +29,7 @@ describe("DefaultLoansAPI", () => {
     beforeEach(() => {
         stubbedAssetRegistry = sinon.createStubInstance(DefaultAssetRegistryAPI);
         const transactionAPI = new DefaultTransactionAPI(api);
-        loansApi = new DefaultLoansAPI(api, stubbedAssetRegistry, transactionAPI);
+        loansApi = new DefaultLoansAPI(api, KBtc, stubbedAssetRegistry, transactionAPI);
     });
 
     describe("getLendPositionsOfAccount", () => {

--- a/test/utils/helpers.ts
+++ b/test/utils/helpers.ts
@@ -395,5 +395,5 @@ export function includesStringified<T extends ImplementsToString>(arr: Array<T>,
     if (arr.length == 0) {
         return false;
     }
-    return arr.map((accountId) => accountId.toString() == element.toString()).reduce((acc, value) => acc || value);
+    return arr.map((x) => x.toString() == element.toString()).reduce((acc, value) => acc || value);
 }

--- a/test/utils/helpers.ts
+++ b/test/utils/helpers.ts
@@ -381,3 +381,19 @@ export function getCorrespondingCollateralCurrenciesForTests(
             throw new Error("Provided currency is not a governance currency");
     }
 }
+
+type ImplementsToString = { toString: () => string };
+/**
+ * Alternative to `arr.includes(element)` that check stringified version of the items for equality.
+ * Useful for types such as `AccountId`.
+ * @param arr
+ * @param element
+ * @returns a boolean representing the presence of the stringified version of `elements` amongts the
+ * stringified items of `arr`
+ */
+export function includesStringified<T extends ImplementsToString>(arr: Array<T>, element: T): boolean {
+    if (arr.length == 0) {
+        return false;
+    }
+    return arr.map((accountId) => accountId.toString() == element.toString()).reduce((acc, value) => acc || value);
+}


### PR DESCRIPTION
Closes https://github.com/interlay/interbtc-api/issues/567

Breaking changes:
- the `currency` property is removed from `LoanPosition` because it's not required
- `LendPosition` is renamed to `CollateralPosition` because it's easier to distinguish from `LoanPosiiton`
- Unrelated, but since we're make breaking changes: `getBlockRewardAPY` and `computeReward` have their unused parameters removed
