### PR TITLE
Peter/loans feat fetch prices on chain

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@interlay/interbtc-api",
-  "version": "0.32.9",
+  "version": "0.32.10",
   "description": "JavaScript library to interact with interBTC and kBTC",
   "main": "build/src/index.js",
   "typings": "build/src/index.d.ts",

--- a/src/interbtc-api.ts
+++ b/src/interbtc-api.ts
@@ -108,10 +108,10 @@ export class DefaultInterBtcApi implements InterBtcApi {
         this.transactionAPI = new DefaultTransactionAPI(api, _account);
 
         this.assetRegistry = new DefaultAssetRegistryAPI(api);
-        this.loans = new DefaultLoansAPI(api, this.transactionAPI);
+        this.oracle = new DefaultOracleAPI(api, wrappedCurrency, this.transactionAPI);
+        this.loans = new DefaultLoansAPI(api, this.transactionAPI, this.oracle);
         this.tokens = new DefaultTokensAPI(api, this.transactionAPI);
         this.system = new DefaultSystemAPI(api, this.transactionAPI);
-        this.oracle = new DefaultOracleAPI(api, wrappedCurrency, this.transactionAPI);
         this.fee = new DefaultFeeAPI(api, this.oracle);
         this.rewards = new DefaultRewardsAPI(api, wrappedCurrency, this.transactionAPI);
         this.escrow = new DefaultEscrowAPI(api, governanceCurrency, this.system, this.transactionAPI);

--- a/src/parachain/loans.ts
+++ b/src/parachain/loans.ts
@@ -375,14 +375,14 @@ export class DefaultLoansAPI implements LoansAPI {
         loanAssets: TickerToData<LoanAsset>
     ): LoanCollateralInfo {
         const lendCollateralPositions = lendPositions.filter(({ isCollateral }) => isCollateral);
-        const lendCollateralThresholdAdjustedPositions = lendPositions.map((position) => {
+        const lendCollateralThresholdAdjustedPositions = lendCollateralPositions.map((position) => {
             const collateralTheshold = loanAssets[position.currency.ticker].collateralThreshold;
             return {
                 ...position,
                 amount: adjustToThreshold(position.amount, collateralTheshold),
             };
         });
-        const lendLiquidationThresholdAdjustedPositions = lendPositions.map((position) => {
+        const lendLiquidationThresholdAdjustedPositions = lendCollateralPositions.map((position) => {
             const liquidationThreshold = loanAssets[position.currency.ticker].liquidationThreshold;
             return {
                 ...position,
@@ -544,8 +544,8 @@ export class DefaultLoansAPI implements LoansAPI {
         const wrappedCurrencyId = this.api.consts.escrowRewards.getWrappedCurrencyId;
         const wrappedCurrency = tokenSymbolToCurrency(wrappedCurrencyId.asToken);
         if (isCurrencyEqual(fromCurrency, wrappedCurrency)) {
-            const oneWrappedCurrencyAtomic = Big(10).pow(wrappedCurrency.decimals);
-            return new ExchangeRate(wrappedCurrency, wrappedCurrency, oneWrappedCurrencyAtomic);
+            const wrappedCurrencyToBitcoinRate = Big(1); // Use exchange rate of 1 between wrapped BTC and real BTC.
+            return new ExchangeRate(wrappedCurrency, wrappedCurrency, wrappedCurrencyToBitcoinRate);
         }
         return this.oracleAPI.getExchangeRate(fromCurrency);
     }

--- a/src/parachain/loans.ts
+++ b/src/parachain/loans.ts
@@ -544,7 +544,7 @@ export class DefaultLoansAPI implements LoansAPI {
         const wrappedCurrencyId = this.api.consts.escrowRewards.getWrappedCurrencyId;
         const wrappedCurrency = tokenSymbolToCurrency(wrappedCurrencyId.asToken);
         if (isCurrencyEqual(fromCurrency, wrappedCurrency)) {
-            const wrappedCurrencyToBitcoinRate = Big(1); // Use exchange rate of 1 between wrapped BTC and real BTC.
+            const wrappedCurrencyToBitcoinRate = Big(1);
             return new ExchangeRate(wrappedCurrency, wrappedCurrency, wrappedCurrencyToBitcoinRate);
         }
         return this.oracleAPI.getExchangeRate(fromCurrency);

--- a/src/types/loans.ts
+++ b/src/types/loans.ts
@@ -1,4 +1,4 @@
-import { MonetaryAmount } from "@interlay/monetary-js";
+import { Bitcoin, ExchangeRate, MonetaryAmount } from "@interlay/monetary-js";
 import Big from "big.js";
 import { CurrencyExt } from "./currency";
 
@@ -15,6 +15,22 @@ interface BorrowPosition extends LoanPosition {
     accumulatedDebt: MonetaryAmount<CurrencyExt>;
 }
 
+type LoanAction = "lend" | "withdraw" | "borrow" | "repay";
+interface LoanCollateralInfo {
+    totalLentBtc: MonetaryAmount<Bitcoin>;
+    totalBorrowedBtc: MonetaryAmount<Bitcoin>;
+    totalCollateralBtc: MonetaryAmount<Bitcoin>;
+    borrowLimitBtc: MonetaryAmount<Bitcoin>;
+    ltv: Big;
+    collateralThresholdWeightedAverage: Big; // Decimal.
+    liquidationThresholdWeightedAverage: Big; // Decimal.
+    calculateBorrowLimitBtcChange: (action: LoanAction, amount: MonetaryAmount<CurrencyExt>) => MonetaryAmount<Bitcoin>;
+    calculateLtvAndThresholdsChange: (
+        action: LoanAction,
+        amount: MonetaryAmount<CurrencyExt>
+    ) => { ltv: Big; collateralThresholdWeightedAverage: Big; liquidationThresholdWeightedAverage: Big };
+}
+
 interface LoanAsset {
     currency: CurrencyExt;
     lendApy: Big; // percentage
@@ -29,6 +45,7 @@ interface LoanAsset {
     isActive: boolean;
     supplyCap: MonetaryAmount<CurrencyExt>;
     borrowCap: MonetaryAmount<CurrencyExt>;
+    exchangeRate: ExchangeRate<Bitcoin, CurrencyExt>;
 }
 
 // Enables easier access to data by asset ticker key.
@@ -40,4 +57,13 @@ interface LoanMarket {
     lendTokenId: number;
 }
 
-export type { LoanPosition, LendPosition, BorrowPosition, LoanAsset, TickerToData, LoanMarket };
+export type {
+    LoanPosition,
+    LendPosition,
+    BorrowPosition,
+    LoanAsset,
+    TickerToData,
+    LoanMarket,
+    LoanCollateralInfo,
+    LoanAction,
+};

--- a/src/types/loans.ts
+++ b/src/types/loans.ts
@@ -16,9 +16,9 @@ interface BorrowPosition extends LoanPosition {
 }
 
 type LoanAction = "lend" | "withdraw" | "borrow" | "repay";
-interface LoanCollateralInfo {
-    totalLentBtc: MonetaryAmount<Bitcoin>;
-    totalBorrowedBtc: MonetaryAmount<Bitcoin>;
+interface LendingStats {
+    totalLentBtc: MonetaryAmount<Bitcoin>; // Includes earned amount.
+    totalBorrowedBtc: MonetaryAmount<Bitcoin>; // Includes debt.
     totalCollateralBtc: MonetaryAmount<Bitcoin>;
     borrowLimitBtc: MonetaryAmount<Bitcoin>;
     ltv: Big;
@@ -64,6 +64,6 @@ export type {
     LoanAsset,
     TickerToData,
     LoanMarket,
-    LoanCollateralInfo,
+    LendingStats,
     LoanAction,
 };

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -6,3 +6,4 @@ export * from "./bitcoin-core-client";
 export * from "./issueRedeem";
 export * from "./storage";
 export * from "./rewards";
+export * from "./loans";

--- a/src/utils/loans.ts
+++ b/src/utils/loans.ts
@@ -1,0 +1,151 @@
+import { Bitcoin, MonetaryAmount } from "@interlay/monetary-js";
+import Big from "big.js";
+import { newMonetaryAmount } from "..";
+import { LoanAction, CurrencyExt, LoanAsset, LoanPosition, TickerToData } from "../types";
+
+const calculateTotalBorrowedBtcChange = (
+    action: LoanAction,
+    currentTotalBorrowedBtc: MonetaryAmount<Bitcoin>,
+    actionAmountBtc: MonetaryAmount<Bitcoin>
+): MonetaryAmount<Bitcoin> => {
+    switch (action) {
+        case "borrow":
+            return currentTotalBorrowedBtc.add(actionAmountBtc);
+        case "repay":
+            return currentTotalBorrowedBtc.sub(actionAmountBtc);
+        default:
+            return currentTotalBorrowedBtc;
+    }
+};
+
+const calculateCollateralAmountBtc = (
+    action: LoanAction,
+    currentCollateralAmountBtc: MonetaryAmount<Bitcoin>,
+    actionAmountBtc: MonetaryAmount<Bitcoin>
+): MonetaryAmount<Bitcoin> => {
+    switch (action) {
+        case "lend":
+            return currentCollateralAmountBtc.add(actionAmountBtc);
+        case "withdraw":
+            return currentCollateralAmountBtc.sub(actionAmountBtc);
+        default:
+            return currentCollateralAmountBtc;
+    }
+};
+
+const adjustToThreshold = (amount: MonetaryAmount<CurrencyExt>, threshold: Big): MonetaryAmount<CurrencyExt> =>
+    amount.mul(threshold);
+
+const calculateBorrowLimit = (
+    totalBorrowedAmount: MonetaryAmount<CurrencyExt>,
+    totalCollateralThresholdAdjustedAmount: MonetaryAmount<CurrencyExt>
+): MonetaryAmount<CurrencyExt> => totalCollateralThresholdAdjustedAmount.sub(totalBorrowedAmount);
+
+const getTotalAmountBtc = (
+    positions: Array<LoanPosition>,
+    loanAssets: TickerToData<LoanAsset>
+): MonetaryAmount<Bitcoin> =>
+    positions.reduce((total, { amount }) => {
+        const { exchangeRate } = loanAssets[amount.currency.ticker];
+        const amountBtc = exchangeRate.toBase(amount);
+        return total.add(amountBtc);
+    }, newMonetaryAmount(0, Bitcoin));
+
+const calculateThreshold = (
+    collateralAmount: MonetaryAmount<CurrencyExt>,
+    thresholdAdjustedCollateralAmount: MonetaryAmount<CurrencyExt>
+): Big => {
+    if (collateralAmount.toBig().eq(0)) {
+        return Big(0);
+    }
+    return thresholdAdjustedCollateralAmount.toBig().div(collateralAmount.toBig());
+};
+
+const calculateLtv = (
+    collateralAmount: MonetaryAmount<CurrencyExt>,
+    borrowedAmount: MonetaryAmount<CurrencyExt>
+): Big => {
+    if (collateralAmount.toBig().eq(0)) {
+        return Big(0);
+    }
+    return borrowedAmount.toBig().div(collateralAmount.toBig());
+};
+
+const calculateBorrowLimitBtcChangeFactory =
+    (
+        loanAssets: TickerToData<LoanAsset>,
+        totalBorrowedBtc: MonetaryAmount<Bitcoin>,
+        totalCollateralThresholdAdjustedCollateralBtc: MonetaryAmount<Bitcoin>
+    ) =>
+    (action: LoanAction, amount: MonetaryAmount<CurrencyExt>): MonetaryAmount<Bitcoin> => {
+        const { collateralThreshold, exchangeRate } = loanAssets[amount.currency.ticker];
+
+        const amountBtc = exchangeRate.toBase(amount);
+        const collateralThresholdAdjustedAmountBtc = adjustToThreshold(amount, collateralThreshold);
+
+        const newTotalBorrowedBtc = calculateTotalBorrowedBtcChange(action, totalBorrowedBtc, amountBtc);
+        const newTotalCollateralThresholdAdjustedCollateralBtc = calculateCollateralAmountBtc(
+            action,
+            totalCollateralThresholdAdjustedCollateralBtc,
+            collateralThresholdAdjustedAmountBtc
+        );
+
+        return calculateBorrowLimit(newTotalBorrowedBtc, newTotalCollateralThresholdAdjustedCollateralBtc);
+    };
+
+const calculateLtvAndThresholdsChangeFactory =
+    (
+        loanAssets: TickerToData<LoanAsset>,
+        totalBorrowedBtc: MonetaryAmount<Bitcoin>,
+        totalCollateralBtc: MonetaryAmount<Bitcoin>,
+        totalCollateralThresholdAdjustedCollateralBtc: MonetaryAmount<Bitcoin>,
+        totalLiquidationThresholdAdjustedCollateralBtc: MonetaryAmount<Bitcoin>
+    ) =>
+    (action: LoanAction, amount: MonetaryAmount<CurrencyExt>) => {
+        const { collateralThreshold, liquidationThreshold, exchangeRate } = loanAssets[amount.currency.ticker];
+
+        const amountBtc = exchangeRate.toBase(amount);
+        const collateralThresholdAdjustedAmountBtc = adjustToThreshold(amount, collateralThreshold);
+        const liquidationThresholdAdjustedAmountBtc = adjustToThreshold(amount, liquidationThreshold);
+
+        const newTotalBorrowedBtc = calculateTotalBorrowedBtcChange(action, totalBorrowedBtc, amountBtc);
+        const newTotalCollateralBtc = calculateCollateralAmountBtc(action, totalCollateralBtc, amountBtc);
+        const newTotalCollateralThresholdAdjustedCollateralBtc = calculateCollateralAmountBtc(
+            action,
+            totalCollateralThresholdAdjustedCollateralBtc,
+            collateralThresholdAdjustedAmountBtc
+        );
+        const newTotalLiquidationThresholdAdjustedCollateralBtc = calculateCollateralAmountBtc(
+            action,
+            totalLiquidationThresholdAdjustedCollateralBtc,
+            liquidationThresholdAdjustedAmountBtc
+        );
+
+        const ltv = calculateLtv(newTotalCollateralBtc, newTotalBorrowedBtc);
+        const collateralThresholdWeightedAverage = calculateThreshold(
+            newTotalCollateralBtc,
+            newTotalCollateralThresholdAdjustedCollateralBtc
+        );
+        const liquidationThresholdWeightedAverage = calculateThreshold(
+            newTotalCollateralBtc,
+            newTotalLiquidationThresholdAdjustedCollateralBtc
+        );
+
+        return {
+            ltv,
+            collateralThresholdWeightedAverage,
+            liquidationThresholdWeightedAverage,
+        };
+    };
+
+export {
+    calculateBorrowLimit,
+    adjustToThreshold,
+    calculateCollateralAmountBtc,
+    calculateTotalBorrowedBtcChange,
+    getTotalAmountBtc,
+    calculateLtv,
+    calculateThreshold,
+    calculateBorrowLimitBtcChangeFactory,
+    calculateLtvAndThresholdsChangeFactory,
+};

--- a/src/utils/loans.ts
+++ b/src/utils/loans.ts
@@ -39,7 +39,8 @@ const adjustToThreshold = (amount: MonetaryAmount<CurrencyExt>, threshold: Big):
 const calculateBorrowLimit = (
     totalBorrowedAmount: MonetaryAmount<CurrencyExt>,
     totalCollateralThresholdAdjustedAmount: MonetaryAmount<CurrencyExt>
-): MonetaryAmount<CurrencyExt> => totalCollateralThresholdAdjustedAmount.sub(totalBorrowedAmount).max(0);
+): MonetaryAmount<CurrencyExt> =>
+    totalCollateralThresholdAdjustedAmount.sub(totalBorrowedAmount).max(newMonetaryAmount(0, Bitcoin));
 
 const getTotalAmountBtc = (
     positions: Array<LoanPosition>,
@@ -81,7 +82,7 @@ const calculateBorrowLimitBtcChangeFactory =
         const { collateralThreshold, exchangeRate } = loanAssets[amount.currency.ticker];
 
         const amountBtc = exchangeRate.toBase(amount);
-        const collateralThresholdAdjustedAmountBtc = adjustToThreshold(amount, collateralThreshold);
+        const collateralThresholdAdjustedAmountBtc = adjustToThreshold(amountBtc, collateralThreshold);
 
         const newTotalBorrowedBtc = calculateTotalBorrowedBtcChange(action, totalBorrowedBtc, amountBtc);
         const newTotalCollateralThresholdAdjustedCollateralBtc = calculateCollateralAmountBtc(
@@ -101,12 +102,19 @@ const calculateLtvAndThresholdsChangeFactory =
         totalCollateralThresholdAdjustedCollateralBtc: MonetaryAmount<Bitcoin>,
         totalLiquidationThresholdAdjustedCollateralBtc: MonetaryAmount<Bitcoin>
     ) =>
-    (action: LoanAction, amount: MonetaryAmount<CurrencyExt>) => {
+    (
+        action: LoanAction,
+        amount: MonetaryAmount<CurrencyExt>
+    ): {
+        ltv: Big;
+        collateralThresholdWeightedAverage: Big;
+        liquidationThresholdWeightedAverage: Big;
+    } => {
         const { collateralThreshold, liquidationThreshold, exchangeRate } = loanAssets[amount.currency.ticker];
 
         const amountBtc = exchangeRate.toBase(amount);
-        const collateralThresholdAdjustedAmountBtc = adjustToThreshold(amount, collateralThreshold);
-        const liquidationThresholdAdjustedAmountBtc = adjustToThreshold(amount, liquidationThreshold);
+        const collateralThresholdAdjustedAmountBtc = adjustToThreshold(amountBtc, collateralThreshold);
+        const liquidationThresholdAdjustedAmountBtc = adjustToThreshold(amountBtc, liquidationThreshold);
 
         const newTotalBorrowedBtc = calculateTotalBorrowedBtcChange(action, totalBorrowedBtc, amountBtc);
         const newTotalCollateralBtc = calculateCollateralAmountBtc(action, totalCollateralBtc, amountBtc);

--- a/src/utils/loans.ts
+++ b/src/utils/loans.ts
@@ -39,7 +39,7 @@ const adjustToThreshold = (amount: MonetaryAmount<CurrencyExt>, threshold: Big):
 const calculateBorrowLimit = (
     totalBorrowedAmount: MonetaryAmount<CurrencyExt>,
     totalCollateralThresholdAdjustedAmount: MonetaryAmount<CurrencyExt>
-): MonetaryAmount<CurrencyExt> => totalCollateralThresholdAdjustedAmount.sub(totalBorrowedAmount);
+): MonetaryAmount<CurrencyExt> => totalCollateralThresholdAdjustedAmount.sub(totalBorrowedAmount).max(0);
 
 const getTotalAmountBtc = (
     positions: Array<LoanPosition>,

--- a/test/unit/parachain/loans.test.ts
+++ b/test/unit/parachain/loans.test.ts
@@ -1,9 +1,8 @@
-import sinon from "sinon";
 import { ApiPromise } from "@polkadot/api";
 import {
     CurrencyExt,
-    DefaultAssetRegistryAPI,
     DefaultLoansAPI,
+    DefaultOracleAPI,
     DefaultTransactionAPI,
     newMonetaryAmount,
 } from "../../../src/";
@@ -11,10 +10,10 @@ import { getAPITypes } from "../../../src/factory";
 import Big from "big.js";
 import { expect } from "chai";
 import { Interlay, MonetaryAmount, Polkadot } from "@interlay/monetary-js";
+import { getWrappedCurrencyForTest } from "test/utils/helpers";
 
 describe("DefaultLoansAPI", () => {
     let api: ApiPromise;
-    let stubbedAssetRegistry: sinon.SinonStubbedInstance<DefaultAssetRegistryAPI>;
     let loansApi: DefaultLoansAPI;
     const testGovernanceCurrency = Interlay;
 
@@ -28,7 +27,9 @@ describe("DefaultLoansAPI", () => {
 
     beforeEach(() => {
         const transactionAPI = new DefaultTransactionAPI(api);
-        loansApi = new DefaultLoansAPI(api, transactionAPI);
+        const wrappedCurrency = getWrappedCurrencyForTest(api);
+        const oracleAPI = new DefaultOracleAPI(api, wrappedCurrency, transactionAPI);
+        loansApi = new DefaultLoansAPI(api, transactionAPI, oracleAPI);
     });
 
     describe("getLendPositionsOfAccount", () => {

--- a/test/unit/parachain/loans.test.ts
+++ b/test/unit/parachain/loans.test.ts
@@ -1,21 +1,27 @@
+/* eslint-disable max-len */
 import { ApiPromise } from "@polkadot/api";
 import {
+    BorrowPosition,
     CurrencyExt,
     DefaultLoansAPI,
     DefaultOracleAPI,
     DefaultTransactionAPI,
+    LendPosition,
+    LoanAsset,
     newMonetaryAmount,
+    TickerToData,
 } from "../../../src/";
 import { getAPITypes } from "../../../src/factory";
-import Big from "big.js";
+import Big, { BigSource } from "big.js";
 import { expect } from "chai";
-import { Interlay, MonetaryAmount, Polkadot } from "@interlay/monetary-js";
-import { getWrappedCurrencyForTest } from "test/utils/helpers";
+import { Bitcoin, ExchangeRate, InterBtc, Interlay, MonetaryAmount, Polkadot } from "@interlay/monetary-js";
 
 describe("DefaultLoansAPI", () => {
     let api: ApiPromise;
     let loansApi: DefaultLoansAPI;
+    const wrappedCurrency = InterBtc;
     const testGovernanceCurrency = Interlay;
+    const testRelayCurrency = Polkadot;
 
     before(() => {
         api = new ApiPromise();
@@ -27,7 +33,6 @@ describe("DefaultLoansAPI", () => {
 
     beforeEach(() => {
         const transactionAPI = new DefaultTransactionAPI(api);
-        const wrappedCurrency = getWrappedCurrencyForTest(api);
         const oracleAPI = new DefaultOracleAPI(api, wrappedCurrency, transactionAPI);
         loansApi = new DefaultLoansAPI(api, transactionAPI, oracleAPI);
     });
@@ -127,6 +132,175 @@ describe("DefaultLoansAPI", () => {
 
         it("should return null if the amount is zero", () => {
             expect(loansApi._getSubsidyReward(Big(0), testGovernanceCurrency)).to.be.null;
+        });
+    });
+
+    describe("getLoanCollateralInfo", () => {
+        const mockLendPosition = (
+            currency: CurrencyExt,
+            amount: BigSource,
+            isCollateral: boolean = true
+        ): LendPosition => ({
+            amount: newMonetaryAmount(amount, currency),
+            currency,
+            isCollateral,
+        });
+        const mockBorrowPosition = (currency: CurrencyExt, amount: BigSource): BorrowPosition => ({
+            amount: newMonetaryAmount(amount, currency),
+            currency,
+            accumulatedDebt: newMonetaryAmount(0, currency),
+        });
+        const mockLoanAsset = (
+            currency: CurrencyExt,
+            liquidationThreshold: Big,
+            collateralThreshold: Big,
+            exchangeRate: Big
+        ): LoanAsset => ({
+            currency: currency,
+            lendApy: Big(0),
+            borrowApy: Big(0),
+            lendReward: newMonetaryAmount(0, currency),
+            borrowReward: newMonetaryAmount(0, currency),
+            totalLiquidity: newMonetaryAmount(100, currency),
+            availableCapacity: newMonetaryAmount(0, currency),
+            totalBorrows: newMonetaryAmount(0, currency),
+            liquidationThreshold,
+            collateralThreshold,
+            isActive: true,
+            supplyCap: newMonetaryAmount(100000, currency),
+            borrowCap: newMonetaryAmount(100000, currency),
+            exchangeRate: new ExchangeRate(Bitcoin, currency, exchangeRate.div(10 ** Bitcoin.decimals), 0, 0),
+        });
+        const liquidationThresholdGovernanceCurrency = Big(0.5);
+        const liquidationThresholdRelayCurrency = Big(0.25);
+        const liquidationThresholdWrappedCurrency = Big(0.75);
+
+        const collateralThresholdGovernanceCurrency = Big(0.75);
+        const collateralThresholdRelayCurrency = Big(0.5);
+        const collateralThresholdWrappedCurrency = Big(0.9);
+
+        const exchangeRateGovernanceCurrency = Big(200); // 200 GovCurrency/BTC
+        const exchangeRateRelayCurrency = Big(20); // 20 RelayCurrency/BTC
+        const exchangeRateWrappedCurrency = Big(1);
+
+        const loanAssets: TickerToData<LoanAsset> = {
+            [testGovernanceCurrency.ticker]: mockLoanAsset(
+                testGovernanceCurrency,
+                liquidationThresholdGovernanceCurrency,
+                collateralThresholdGovernanceCurrency,
+                exchangeRateGovernanceCurrency
+            ),
+            [testRelayCurrency.ticker]: mockLoanAsset(
+                testRelayCurrency,
+                liquidationThresholdRelayCurrency,
+                collateralThresholdRelayCurrency,
+                exchangeRateRelayCurrency
+            ),
+            [wrappedCurrency.ticker]: mockLoanAsset(
+                wrappedCurrency,
+                liquidationThresholdWrappedCurrency,
+                collateralThresholdWrappedCurrency,
+                exchangeRateWrappedCurrency
+            ),
+        };
+
+        it("should return correct amounts in BTC", () => {
+            const governanceCurrencyLentAmount = Big(100);
+            const relayCurrencyBorrowedAmount = Big(1);
+            const lendPositions = [mockLendPosition(testGovernanceCurrency, governanceCurrencyLentAmount)];
+            const borrowPositions = [mockBorrowPosition(testRelayCurrency, relayCurrencyBorrowedAmount)];
+
+            const expectedTotalLentBtc = governanceCurrencyLentAmount.div(exchangeRateGovernanceCurrency);
+            const expectedTotalBorrowedBtc = relayCurrencyBorrowedAmount.div(exchangeRateRelayCurrency);
+            const expectedTotalCollateralBtc = expectedTotalLentBtc;
+            const expectedBorrowLimitBtc = expectedTotalCollateralBtc
+                .mul(collateralThresholdGovernanceCurrency)
+                .sub(expectedTotalBorrowedBtc);
+
+            const { totalLentBtc, totalBorrowedBtc, totalCollateralBtc, borrowLimitBtc } =
+                loansApi.getLoanCollateralInfo(lendPositions, borrowPositions, loanAssets);
+
+            expect(
+                totalLentBtc.toBig().eq(expectedTotalLentBtc),
+                `Total lent amount: ${totalLentBtc
+                    .toBig()
+                    .toString()} doesn't match expected amount ${expectedTotalLentBtc.toString()}`
+            ).to.be.true;
+            expect(
+                totalBorrowedBtc.toBig().eq(expectedTotalBorrowedBtc),
+                `Total borrowed amount: ${totalBorrowedBtc.toString()} doesn't match expected amount ${expectedTotalBorrowedBtc.toString()}`
+            ).to.be.true;
+            expect(
+                totalCollateralBtc.toBig().eq(expectedTotalCollateralBtc),
+                `Collateral amount: ${totalCollateralBtc.toString()} doesn't match expected amount ${expectedTotalCollateralBtc.toString()}`
+            ).to.be.true;
+            expect(
+                borrowLimitBtc.toBig().eq(expectedBorrowLimitBtc),
+                `Borrow limit amount: ${borrowLimitBtc.toString()} doesn't match expected amount ${expectedBorrowLimitBtc.toString()}`
+            ).to.be.true;
+        });
+
+        it("should compute correct LTV and average thresholds", () => {
+            const governanceCurrencyLentAmount = Big(100);
+            const wrappedCurrencyLentAmount = Big(2);
+            const relayCurrencyLentAmount = Big(1000); // Should not affect the computation since it won't be enabled as collateral.
+
+            const governanceCurrencyBorrowedAmount = Big(10);
+            const relayCurrencyBorrowedAmount = Big(10);
+
+            const governanceCurrencyCollateralBtc = governanceCurrencyLentAmount.div(exchangeRateGovernanceCurrency);
+            const wrappedCurrencyCollateralBtc = wrappedCurrencyLentAmount.div(exchangeRateWrappedCurrency);
+            const totalCollateralAmountBtc = governanceCurrencyCollateralBtc.add(wrappedCurrencyCollateralBtc);
+
+            const governanceCurrencyBorrowedBtc = governanceCurrencyBorrowedAmount.div(exchangeRateGovernanceCurrency);
+            const relayCurrencyBorrowedBtc = relayCurrencyBorrowedAmount.div(exchangeRateRelayCurrency);
+            const totalBorrowedAmountBtc = governanceCurrencyBorrowedBtc.add(relayCurrencyBorrowedBtc);
+
+            const totalCollateralThresholdAdjustedCollateralAmountBtc = governanceCurrencyCollateralBtc
+                .mul(collateralThresholdGovernanceCurrency)
+                .add(wrappedCurrencyCollateralBtc.mul(collateralThresholdWrappedCurrency));
+            const totalLiquidationThresholdAdjustedCollateralAmountBtc = governanceCurrencyCollateralBtc
+                .mul(liquidationThresholdGovernanceCurrency)
+                .add(wrappedCurrencyCollateralBtc.mul(liquidationThresholdWrappedCurrency));
+
+            const lendPositions = [
+                mockLendPosition(testGovernanceCurrency, governanceCurrencyLentAmount),
+                mockLendPosition(testRelayCurrency, relayCurrencyLentAmount, false),
+                mockLendPosition(wrappedCurrency, wrappedCurrencyLentAmount),
+            ];
+            const borrowPositions = [
+                mockBorrowPosition(testRelayCurrency, relayCurrencyBorrowedAmount),
+                mockBorrowPosition(testGovernanceCurrency, governanceCurrencyBorrowedAmount),
+            ];
+
+            const { ltv, collateralThresholdWeightedAverage, liquidationThresholdWeightedAverage } =
+                loansApi.getLoanCollateralInfo(lendPositions, borrowPositions, loanAssets);
+
+            const expectedLtv = totalBorrowedAmountBtc.div(totalCollateralAmountBtc);
+            const expectedAverageCollateralThreshold =
+                totalCollateralThresholdAdjustedCollateralAmountBtc.div(totalCollateralAmountBtc);
+            const expectedAverageLiquidationThreshold =
+                totalLiquidationThresholdAdjustedCollateralAmountBtc.div(totalCollateralAmountBtc);
+
+            expect(ltv.eq(expectedLtv), `LTV: ${ltv.toString()} does not match expected LTV: ${expectedLtv.toString()}`)
+                .to.be.true;
+            expect(
+                collateralThresholdWeightedAverage.eq(expectedAverageCollateralThreshold),
+                `Average collateral threshold: ${collateralThresholdWeightedAverage.toString()} does not match expected threshold: ${expectedAverageCollateralThreshold.toString()}`
+            ).to.be.true;
+            expect(
+                liquidationThresholdWeightedAverage.eq(expectedAverageLiquidationThreshold),
+                `Average liquidation threshold: ${liquidationThresholdWeightedAverage.toString()} does not match expected threshold: ${expectedAverageLiquidationThreshold.toString()}`
+            ).to.be.true;
+        });
+
+        it("should not throw when there are no positions", () => {
+            expect(loansApi.getLoanCollateralInfo([], [], loanAssets)).to.not.throw;
+        });
+
+        it("should not throw when there are no borrow positions", () => {
+            const lendPositions = [mockLendPosition(testGovernanceCurrency, 1)];
+            expect(loansApi.getLoanCollateralInfo(lendPositions, [], loanAssets)).to.not.throw;
         });
     });
 });

--- a/test/utils/helpers.ts
+++ b/test/utils/helpers.ts
@@ -1,6 +1,6 @@
 import { Transaction } from "@interlay/esplora-btc-api";
 import { Bitcoin, ExchangeRate, Kintsugi, Kusama, Polkadot } from "@interlay/monetary-js";
-import { Keyring } from "@polkadot/api";
+import { ApiPromise, Keyring } from "@polkadot/api";
 import { ApiTypes, AugmentedEvent } from "@polkadot/api/types";
 import { KeyringPair } from "@polkadot/keyring/types";
 import { FrameSystemEventRecord } from "@polkadot/types/lookup";
@@ -23,6 +23,8 @@ import {
     createExchangeRateOracleKey,
     getStorageMapItemKey,
     setStorageAtKey,
+    tokenSymbolToCurrency,
+    WrappedCurrency,
 } from "../../src";
 import { SUDO_URI } from "../config";
 import { expect } from "chai";
@@ -380,4 +382,9 @@ export function getCorrespondingCollateralCurrenciesForTests(
         default:
             throw new Error("Provided currency is not a governance currency");
     }
+}
+
+export function getWrappedCurrencyForTest(api: ApiPromise): WrappedCurrency {
+    const currencyId = api.consts.escrowRewards.getWrappedCurrencyId;
+    return tokenSymbolToCurrency(currencyId.asToken);
 }


### PR DESCRIPTION
Moving price fetching from UI to lib, replacing CoinGecko and using on-chain oracle as price source for LTV, collateralization and average thresholds computation.

Added `getCollateralInfo` method takes parameters `lendPositions`, `borrowPositions`, and `loanAssets`. All of these are returned from lib methods `getLendPositionsOfAccount`, `getBorrowPositionsOfAccount` and `getLoanAssets`, respectively. `getLoanAssets` was extended with call to oracle pallet to get asset's exchange rate against bitcoin which is exposed in the `LoanAsset` object. Therefore `getCollateralInfo` method can be run synchronously. This method computes and returns `LoanCollateralInfo`.
`LoanCollateralInfo` is interface consisting of following properties and methods that can be later used on UI side:
- `totalLentBtc` - total aggregated amount of all supplied assets in BTC value
- `totalCollateralBtc` - total aggregated amount of all supplied assets used as collateral in BTC value
- `totalBorrowedBtc` - total aggregated amount of all borrowed assets in BTC value
- `borrowLimitBtc` - total amount that can be borrowed until collateral threshold is met, denominated in BTC
- `ltv` - loan to value 
- `collateralThresholdWeightedAverage` - Average collateral threshold. Denominated in decimals. 
- `liquidationThresholdWeightedAverage` - Average liquidation threshold. Denominated in decimals.
- `calculateBorrowLimitBtcChange` - helper function to compute values based on user's input - to replace similar helper on UI
- `calculateLtvAndThresholdsChange` -helper function that computes new LTV and thresholds based on user's action and input. Replacement for helper on UI.

Note:
All of these properties and methods are equivalent to what is being computed on UI side and should be used to replace UI logic. 

**Next steps on the UI side:**
- Replace logic on UI side with call to `getCollateralInfo` which already pre-computes all the needed values.
- Convert BTC values to USD using price from CoinGecko - should be only for preview purposes 