### PR TITLE
refactor: use api for storage setters

### DIFF
--- a/src/utils/setup.ts
+++ b/src/utils/setup.ts
@@ -1,7 +1,6 @@
 /* eslint @typescript-eslint/no-var-requires: "off" */
 import { ExchangeRate, Bitcoin } from "@interlay/monetary-js";
 import { Big } from "big.js";
-import BN from "bn.js";
 import { ApiPromise } from "@polkadot/api";
 import { setNumericStorage } from "./storage";
 import { NominationAPI, OracleAPI } from "../parachain";
@@ -21,16 +20,14 @@ export async function initializeStableConfirmations(
     console.log("Initializing stable block confirmations...");
     await setNumericStorage(
         api,
-        "BTCRelay",
-        "StableBitcoinConfirmations",
-        new BN(stableConfirmationsToSet.bitcoinConfirmations),
+        api.query.btcRelay.stableBitcoinConfirmations.key(),
+        api.createType("u32", stableConfirmationsToSet.bitcoinConfirmations),
         account
     );
     await setNumericStorage(
         api,
-        "BTCRelay",
-        "StableParachainConfirmations",
-        new BN(stableConfirmationsToSet.parachainConfirmations),
+        api.query.btcRelay.stableParachainConfirmations.key(),
+        api.createType("u32", stableConfirmationsToSet.parachainConfirmations),
         account
     );
     await bitcoinCoreClient.mineBlocks(3);

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -1,60 +1,17 @@
-import { xxhashAsHex, blake2AsHex } from "@polkadot/util-crypto";
-import { bnToHex } from "@polkadot/util";
-import { StorageKey, Bytes } from "@polkadot/types/primitive";
 import { ApiPromise } from "@polkadot/api";
-import BN from "bn.js";
-import { ITuple } from "@polkadot/types/types";
+import { Codec } from "@polkadot/types/types";
 import { AddressOrPair } from "@polkadot/api/types";
 
-import { stripHexPrefix } from "./encoding";
 import { DefaultTransactionAPI } from "../parachain";
-
-export function getStorageKey(moduleName: string, storageItemName: string): string {
-    return xxhashAsHex(moduleName, 128) + stripHexPrefix(xxhashAsHex(storageItemName, 128));
-}
-
-export function blake2_128Concat(data: `0x${string}`): string {
-    return blake2AsHex(data, 128) + stripHexPrefix(data);
-}
-
-export function getStorageMapItemKey(
-    moduleName: string,
-    storageItemName: string,
-    mapItemKey: `0x${string}`,
-    nestedMapItemKey?: `0x${string}`
-): string {
-    let storageKey = getStorageKey(moduleName, storageItemName) + stripHexPrefix(blake2_128Concat(mapItemKey));
-    if (nestedMapItemKey) {
-        storageKey += stripHexPrefix(blake2_128Concat(nestedMapItemKey));
-    }
-    return storageKey;
-}
 
 export async function setNumericStorage(
     api: ApiPromise,
-    moduleName: string,
-    storageItemName: string,
-    value: BN,
+    key: string,
+    value: Codec,
     account: AddressOrPair,
-    bits = 32,
     isLittleEndian = true
 ): Promise<void> {
-    const data = bnToHex(value, { bitLength: bits, isLe: isLittleEndian });
-    await setStorage(api, moduleName, storageItemName, data, account);
-}
-
-async function setStorage(
-    api: ApiPromise,
-    moduleName: string,
-    storageItemName: string,
-    data: string,
-    account: AddressOrPair
-): Promise<void> {
-    const key = getStorageKey(moduleName, storageItemName);
-    const storageKey = api.createType("StorageKey", key);
-    const storageData = api.createType("StorageData", data);
-    const tx = api.tx.sudo.sudo(api.tx.system.setStorage([[storageKey, storageData] as ITuple<[StorageKey, Bytes]>]));
-    await DefaultTransactionAPI.sendLogged(api, account, tx, undefined, true);
+    await setStorageAtKey(api, key, value.toHex(isLittleEndian), account);
 }
 
 export async function setStorageAtKey(
@@ -65,14 +22,4 @@ export async function setStorageAtKey(
 ): Promise<void> {
     const tx = api.tx.sudo.sudo(api.tx.system.setStorage([[key, data]]));
     await DefaultTransactionAPI.sendLogged(api, sudoAccount, tx, undefined, true);
-}
-
-export async function setStorageAtKeyBatch(
-    api: ApiPromise,
-    newStorage: [string, `0x${string}`][],
-    sudoAccount: AddressOrPair
-): Promise<void> {
-    const txs = newStorage.map((storage) => api.tx.sudo.sudo(api.tx.system.setStorage([storage])));
-    const batchedTxs = api.tx.utility.batchAll(txs);
-    await DefaultTransactionAPI.sendLogged(api, sudoAccount, batchedTxs, undefined, true);
 }

--- a/test/integration/parachain/staging/sequential/asset-registry.test.ts
+++ b/test/integration/parachain/staging/sequential/asset-registry.test.ts
@@ -4,7 +4,6 @@ import { KeyringPair } from "@polkadot/keyring/types";
 import { createSubstrateAPI } from "../../../../../src/factory";
 import { ESPLORA_BASE_PATH, PARACHAIN_ENDPOINT, SUDO_URI } from "../../../../config";
 import { DefaultAssetRegistryAPI, DefaultInterBtcApi, storageKeyToNthInner, stripHexPrefix } from "../../../../../src";
-import { getStorageKey } from "../../../../../src/utils/storage";
 
 import { StorageKey } from "@polkadot/types";
 import { AnyTuple } from "@polkadot/types/types";
@@ -29,7 +28,7 @@ describe("AssetRegistry", () => {
         sudoAccount = keyring.addFromUri(SUDO_URI);
         interBtcAPI = new DefaultInterBtcApi(api, "regtest", sudoAccount, ESPLORA_BASE_PATH);
 
-        assetRegistryMetadataHash = getStorageKey("AssetRegistry", "Metadata");
+        assetRegistryMetadataHash = api.query.assetRegistry.metadata.key();
         // check which keys exist before the tests
         const keys = await interBtcAPI.api.rpc.state.getKeys(assetRegistryMetadataHash);
         registeredKeysBefore = keys.toArray();

--- a/test/integration/parachain/staging/sequential/asset-registry.test.ts
+++ b/test/integration/parachain/staging/sequential/asset-registry.test.ts
@@ -18,7 +18,7 @@ describe("AssetRegistry", () => {
 
     let sudoAccount: KeyringPair;
 
-    let assetRegistryMetadataHash: string;
+    let assetRegistryMetadataPrefix: string;
     let registeredKeysBefore: StorageKey<AnyTuple>[] = [];
 
     before(async () => {
@@ -28,15 +28,15 @@ describe("AssetRegistry", () => {
         sudoAccount = keyring.addFromUri(SUDO_URI);
         interBtcAPI = new DefaultInterBtcApi(api, "regtest", sudoAccount, ESPLORA_BASE_PATH);
 
-        assetRegistryMetadataHash = api.query.assetRegistry.metadata.key();
+        assetRegistryMetadataPrefix = api.query.assetRegistry.metadata.keyPrefix();
         // check which keys exist before the tests
-        const keys = await interBtcAPI.api.rpc.state.getKeys(assetRegistryMetadataHash);
+        const keys = await interBtcAPI.api.rpc.state.getKeys(assetRegistryMetadataPrefix);
         registeredKeysBefore = keys.toArray();
     });
 
     after(async () => {
         // clean up keys created in tests if necessary
-        const registeredKeysAfter = (await interBtcAPI.api.rpc.state.getKeys(assetRegistryMetadataHash)).toArray();
+        const registeredKeysAfter = (await interBtcAPI.api.rpc.state.getKeys(assetRegistryMetadataPrefix)).toArray();
 
         const previousKeyHashes = registeredKeysBefore.map((key) => stripHexPrefix(key.toHex()));
         // need to use string comparison since the raw StorageKeys don't play nicely with .filter()
@@ -66,7 +66,7 @@ describe("AssetRegistry", () => {
      */
     it("should get expected shape of AssetRegistry metadata", async () => {
         // check if any assets have been registered
-        const existingKeys = (await interBtcAPI.api.rpc.state.getKeys(assetRegistryMetadataHash)).toArray();
+        const existingKeys = (await interBtcAPI.api.rpc.state.getKeys(assetRegistryMetadataPrefix)).toArray();
 
         if (existingKeys.length === 0) {
             // no existing foreign assets; register a new foreign asset for the test

--- a/test/integration/parachain/staging/sequential/escrow.test.ts
+++ b/test/integration/parachain/staging/sequential/escrow.test.ts
@@ -127,11 +127,9 @@ describe("escrow", () => {
 
         await setNumericStorage(
             api,
-            "EscrowAnnuity",
-            "RewardPerBlock",
-            new BN(firstYearRewards / blocksPerYear),
+            api.query.escrowAnnuity.rewardPerBlock.key(),
+            api.createType("Balance", new BN(firstYearRewards / blocksPerYear)),
             sudoAccount,
-            128
         );
 
         const rewardsEstimate = await interBtcAPI.escrow.getRewardEstimate(newAccountId(api, userAccount_1.address));

--- a/test/integration/parachain/staging/sequential/nomination.test.ts
+++ b/test/integration/parachain/staging/sequential/nomination.test.ts
@@ -114,7 +114,12 @@ describe.skip("NominationAPI", () => {
     }).timeout(2 * 60000);
 
     async function setIssueFee(x: BN) {
-        await setNumericStorage(api, "Fee", "IssueFee", x, sudoAccount, 128);
+        await setNumericStorage(
+            api,
+            api.query.fee.issueFee.key(),
+            api.createType("UnsignedFixedPoint", x),
+            sudoAccount,
+        );
     }
 
     it("Should nominate to and withdraw from a vault", async () => {

--- a/test/integration/parachain/staging/setup/initialize.test.ts
+++ b/test/integration/parachain/staging/setup/initialize.test.ts
@@ -239,7 +239,12 @@ describe("Initialize parachain state", () => {
         const timeoutMs = 5 * APPROX_BLOCK_TIME_MS; // aproximately 5 blocks
         const [sudidEventFound] = await Promise.all([
             waitForEvent(sudoInterBtcAPI, api.events.sudo.Sudid, false, timeoutMs),
-            setNumericStorage(sudoInterBtcAPI.api, "Oracle", "MaxDelay", new BN(ORACLE_MAX_DELAY), sudoAccount, 64),
+            setNumericStorage(
+                sudoInterBtcAPI.api,
+                api.query.oracle.maxDelay.key(),
+                api.createType("Moment", new BN(ORACLE_MAX_DELAY)),
+                sudoAccount,
+            ),
         ]);
 
         assert.isTrue(

--- a/test/integration/parachain/staging/utils.test.ts
+++ b/test/integration/parachain/staging/utils.test.ts
@@ -1,0 +1,47 @@
+import { ApiPromise } from "@polkadot/api";
+import { xxhashAsHex, blake2AsHex } from "@polkadot/util-crypto";
+import { bnToHex } from "@polkadot/util";
+import BN from "bn.js";
+
+import { createSubstrateAPI } from "../../../../src/factory";
+import { assert } from "../../../chai";
+import { PARACHAIN_ENDPOINT } from "../../../config";
+import { stripHexPrefix } from "../../../../src";
+
+export function getStorageKey(moduleName: string, storageItemName: string): string {
+    return xxhashAsHex(moduleName, 128) + stripHexPrefix(xxhashAsHex(storageItemName, 128));
+}
+
+export function blake2_128Concat(data: `0x${string}`): string {
+    return blake2AsHex(data, 128) + stripHexPrefix(data);
+}
+
+describe("Utils", () => {
+    let api: ApiPromise;
+
+    before(async () => {
+        api = await createSubstrateAPI(PARACHAIN_ENDPOINT);
+    });
+
+    after(() => {
+        return api.disconnect();
+    });
+
+    it("should encode storage key", async () => {
+        assert.equal(
+            getStorageKey("Oracle", "MaxDelay"),
+            api.query.oracle.maxDelay.key(),
+        );
+    });
+
+    it("should encode storage value", async () => {
+        const value = new BN(100);
+        const data32 = bnToHex(value, { bitLength: 32, isLe: true });
+        const codec32 = api.createType("u32", value);
+        assert.equal(data32, codec32.toHex(true));
+
+        const data64 = bnToHex(value, { bitLength: 64, isLe: true });
+        const codec64 = api.createType("u64", value);
+        assert.equal(data64, codec64.toHex(true));
+    });
+});

--- a/test/integration/parachain/staging/utils.test.ts
+++ b/test/integration/parachain/staging/utils.test.ts
@@ -32,6 +32,10 @@ describe("Utils", () => {
             getStorageKey("Oracle", "MaxDelay"),
             api.query.oracle.maxDelay.key(),
         );
+        assert.equal(
+            getStorageKey("AssetRegistry", "Metadata"),
+            api.query.assetRegistry.metadata.keyPrefix(),
+        )
     });
 
     it("should encode storage value", async () => {

--- a/test/utils/helpers.ts
+++ b/test/utils/helpers.ts
@@ -21,7 +21,6 @@ import {
     CollateralCurrencyExt,
     storageKeyToNthInner,
     createExchangeRateOracleKey,
-    getStorageMapItemKey,
     setStorageAtKey,
 } from "../../src";
 import { SUDO_URI } from "../config";
@@ -111,7 +110,7 @@ export async function callWithExchangeRateOverwritten(
     const exchangeRateOracleKey = createExchangeRateOracleKey(api, currency);
     const initialExchangeRate = (await api.query.oracle.aggregate(exchangeRateOracleKey)).toHex();
 
-    const exchangeRateStorageKey = getStorageMapItemKey("Oracle", "Aggregate", exchangeRateOracleKey.toHex());
+    const exchangeRateStorageKey = api.query.oracle.aggregate.key(exchangeRateOracleKey);
     await setStorageAtKey(sudoInterBtcAPI.api, exchangeRateStorageKey, newExchangeRateHex, sudoAccount);
 
     let result: Promise<void>;


### PR DESCRIPTION
Use polkadot-js for storage key / value encoding instead of rolling it ourselves