### PR TITLE
refactor: use queryMulti for staking computation

### DIFF
--- a/test/integration/parachain/staging/setup/initialize.test.ts
+++ b/test/integration/parachain/staging/setup/initialize.test.ts
@@ -420,6 +420,12 @@ describe("Initialize parachain state", () => {
             const vaultInterBtcApi = new DefaultInterBtcApi(api, "regtest", vaultKeyringPair, ESPLORA_BASE_PATH);
             const collateralAmount = new MonetaryAmount(aUsd, 10000);
             await vaultInterBtcApi.vaults.registerNewCollateralVault(collateralAmount);
+            // sanity check the collateral computation
+            const actualCollateralAmount = await vaultInterBtcApi.vaults.getCollateral(vaultAccountId, aUsd);
+            assert.equal(
+                actualCollateralAmount.toString(),
+                collateralAmount.toString(),
+            );
         }
     });
 

--- a/test/unit/mocks/vaultsTestMocks.ts
+++ b/test/unit/mocks/vaultsTestMocks.ts
@@ -186,7 +186,7 @@ export const prepareLiquidationRateMocks = (
     // if we have less than 2x collateral (in BTC) compared to BTC, we need to liquidate
     sinon.stub(vaultsApi, "getLiquidationCollateralThreshold").returns(Promise.resolve(Big(mockLiquidationThreshold)));
 
-    // mock this.getLockedCollateral return value
-    const mockLockedCollateral = new MonetaryAmount(collateralCurrency, mockCollateralTokensNumber);
-    sinon.stub(vaultsApi, "getLockedCollateral").returns(Promise.resolve(mockLockedCollateral));
+    // mock this.getCollateral return value
+    const mockCollateral = new MonetaryAmount(collateralCurrency, mockCollateralTokensNumber);
+    sinon.stub(vaultsApi, "getCollateral").returns(Promise.resolve(mockCollateral));
 };


### PR DESCRIPTION
Bundle staking queries and remove "duplicate" call `getLockedCollateral` which only checked reserve balance (anyway unused). Add assertion that computation returns correct amount for aUSD Vault.

Related: https://github.com/interlay/interbtc-api/issues/593