### PR TITLE
refactor: use api.at since At() queries are deprecated

### DIFF
--- a/src/parachain/issue.ts
+++ b/src/parachain/issue.ts
@@ -193,7 +193,7 @@ export class DefaultIssueAPI implements IssueAPI {
         private transactionAPI: TransactionAPI,
         private assetRegistryAPI: AssetRegistryAPI,
         private loansAPI: LoansAPI
-    ) {}
+    ) { }
 
     async getRequestLimits(
         vaults?: Map<InterbtcPrimitivesVaultId, MonetaryAmount<WrappedCurrency>>
@@ -352,7 +352,7 @@ export class DefaultIssueAPI implements IssueAPI {
         return await Promise.all(
             issueRequests
                 .filter(([_, req]) => req.isSome.valueOf())
-                // Can be unwrapped because the filter removes `None` values
+                // can be unwrapped because the filter removes `None` values
                 .map(([id, req]) =>
                     parseIssueRequest(
                         this.vaultsAPI,
@@ -387,17 +387,18 @@ export class DefaultIssueAPI implements IssueAPI {
 
     async getRequestsByIds(issueIds: (H256 | string)[]): Promise<Issue[]> {
         const head = await this.api.rpc.chain.getFinalizedHead();
+        const api = await this.api.at(head);
         const issueRequestData = await Promise.all(
             issueIds.map(
                 async (issueId): Promise<[Option<InterbtcPrimitivesIssueIssueRequest>, H256 | string]> =>
                     new Promise((resolve, reject) => {
-                        this.api.query.issue.issueRequests
-                            .at(head, ensureHashEncoded(this.api, issueId))
+                        api.query.issue.issueRequests(ensureHashEncoded(this.api, issueId))
                             .then((request) => resolve([request, issueId]))
                             .catch(reject);
                     })
             )
         );
+        // TODO: pass head to parseIssueRequest since it queries chain state
         return Promise.all(
             issueRequestData
                 .filter(([option, _]) => option.isSome)

--- a/src/parachain/redeem.ts
+++ b/src/parachain/redeem.ts
@@ -229,7 +229,7 @@ export class DefaultRedeemAPI implements RedeemAPI {
         private assetRgistryAPI: AssetRegistryAPI,
         private systemAPI: SystemAPI,
         private loansAPI: LoansAPI
-    ) {}
+    ) { }
 
     private getRedeemIdsFromEvents(events: EventRecord[], event: AugmentedEvent<ApiTypes, AnyTuple>): Hash[] {
         return getRequestIdsFromEvents(events, event, this.api);
@@ -398,16 +398,18 @@ export class DefaultRedeemAPI implements RedeemAPI {
 
     async list(): Promise<Redeem[]> {
         const head = await this.api.rpc.chain.getFinalizedHead();
+        const api = await this.api.at(head);
 
         const [redeemRequests, redeemPeriod, activeBlockNumber] = await Promise.all([
-            this.api.query.redeem.redeemRequests.entriesAt(head),
+            api.query.redeem.redeemRequests.entries(),
             this.getRedeemPeriod(),
             this.systemAPI.getCurrentActiveBlockNumber(head),
         ]);
-        return await Promise.all(
+        // TODO: pass head to parseRedeemRequest since it queries chain state
+        return Promise.all(
             redeemRequests
                 .filter(([_, req]) => req.isSome.valueOf())
-                // Can be unwrapped because the filter removes `None` values
+                // can be unwrapped because the filter removes `None` values
                 .map(([id, req]) => {
                     return parseRedeemRequest(
                         this.vaultsAPI,

--- a/src/parachain/replace.ts
+++ b/src/parachain/replace.ts
@@ -159,7 +159,7 @@ export class DefaultReplaceAPI implements ReplaceAPI {
         private transactionAPI: TransactionAPI,
         private assetRegistryAPI: AssetRegistryAPI,
         private loansAPI: LoansAPI,
-    ) {}
+    ) { }
 
     buildRequestReplaceExtrinsic(
         amount: MonetaryAmount<WrappedCurrency>,
@@ -250,11 +250,12 @@ export class DefaultReplaceAPI implements ReplaceAPI {
 
     async list(): Promise<ReplaceRequestExt[]> {
         const head = await this.api.rpc.chain.getFinalizedHead();
-        const replaceRequests = await this.api.query.replace.replaceRequests.entriesAt(head);
-        return await Promise.all(
+        const api = await this.api.at(head);
+        const replaceRequests = await api.query.replace.replaceRequests.entries();
+        return Promise.all(
             replaceRequests
                 .filter((v) => v[1].isSome.valueOf)
-                // Can be unwrapped because the filter removes `None` values
+                // can be unwrapped because the filter removes `None` values
                 .map(([id, req]) =>
                     parseReplaceRequest(
                         this.assetRegistryAPI,
@@ -270,12 +271,14 @@ export class DefaultReplaceAPI implements ReplaceAPI {
 
     async map(): Promise<Map<H256, ReplaceRequestExt>> {
         const head = await this.api.rpc.chain.getFinalizedHead();
-        const replaceRequests = await this.api.query.replace.replaceRequests.entriesAt(head);
+        const api = await this.api.at(head);
+        const replaceRequests = await api.query.replace.replaceRequests.entries();
         const replaceRequestMap = new Map<H256, ReplaceRequestExt>();
+        // TODO: pass head to parseReplaceRequest since it queries chain state
         await Promise.all(
             replaceRequests
                 .filter((v) => v[1].isSome.valueOf)
-                // Can be unwrapped because the filter removes `None` values
+                // can be unwrapped because the filter removes `None` values
                 .map(
                     ([id, req]) =>
                         new Promise<void>((resolve) => {
@@ -298,10 +301,16 @@ export class DefaultReplaceAPI implements ReplaceAPI {
 
     async getRequestById(replaceId: H256 | string): Promise<ReplaceRequestExt> {
         const head = await this.api.rpc.chain.getFinalizedHead();
+        const api = await this.api.at(head);
+        const replaceRequest = await api.query.replace.replaceRequests(ensureHashEncoded(this.api, replaceId));
+        if (replaceRequest.isNone) {
+            throw new Error("Replace request not found");
+        }
         return parseReplaceRequest(
             this.assetRegistryAPI,
             this.loansAPI,
-            await this.api.query.replace.replaceRequests.at(head, ensureHashEncoded(this.api, replaceId)),
+            // can be unwrapped because we check `None` above
+            replaceRequest.unwrap(),
             this.btcNetwork,
             this.wrappedCurrency,
             replaceId

--- a/src/parachain/system.ts
+++ b/src/parachain/system.ts
@@ -59,15 +59,16 @@ export interface SystemAPI {
 }
 
 export class DefaultSystemAPI implements SystemAPI {
-    constructor(private api: ApiPromise, private transactionAPI: TransactionAPI) {}
+    constructor(private api: ApiPromise, private transactionAPI: TransactionAPI) { }
 
     async getCurrentBlockNumber(): Promise<number> {
         return (await this.api.query.system.number()).toNumber();
     }
 
     async getCurrentActiveBlockNumber(atBlock?: BlockHash): Promise<number> {
-        const block = atBlock || (await this.api.rpc.chain.getFinalizedHead());
-        return (await this.api.query.security.activeBlockCount.at(block)).toNumber();
+        const blockHash = atBlock || (await this.api.rpc.chain.getFinalizedHead());
+        const api = await this.api.at(blockHash);
+        return (await api.query.security.activeBlockCount()).toNumber();
     }
 
     async subscribeToFinalizedBlockHeads(callback: (blockHeader: Header) => void): Promise<() => void> {

--- a/src/parachain/vaults.ts
+++ b/src/parachain/vaults.ts
@@ -515,7 +515,7 @@ export class DefaultVaultsAPI implements VaultsAPI {
 
     async list(atBlock?: BlockHash): Promise<VaultExt[]> {
         const vaultsMap = await (atBlock
-            ? this.api.query.vaultRegistry.vaults.entriesAt(atBlock)
+            ? (await this.api.at(atBlock)).query.vaultRegistry.vaults.entries()
             : this.api.query.vaultRegistry.vaults.entries());
         return Promise.all(vaultsMap.filter((v) => v[1].isSome).map((v) => this.parseVault(v[1].value)));
     }


### PR DESCRIPTION
Closes https://github.com/interlay/interbtc-api/issues/353