### PR TITLE
hotfix: update calculateAPY comparison

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@interlay/interbtc-api",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "JavaScript library to interact with interBTC",
   "main": "build/src/index.js",
   "typings": "build/src/index.d.ts",

--- a/src/parachain/fee.ts
+++ b/src/parachain/fee.ts
@@ -102,7 +102,8 @@ export class DefaultFeeAPI implements FeeAPI {
         lockedCollateral: MonetaryAmount<CollateralCurrencyExt>,
         exchangeRate?: ExchangeRate<Bitcoin, CollateralCurrencyExt>
     ): Promise<Big> {
-        if (lockedCollateral.isZero()) {
+        // TODO: change back to isZero once monetary fix is released.
+        if (lockedCollateral.toBig().eq(0)) {
             return new Big(0);
         }
         if (exchangeRate === undefined) {


### PR DESCRIPTION
Hotfix to get rid of slow loading of Vault Dashboard, proper fix will be to update monetary.js `isZero` comparison to not include lower than minimum decimal amounts into account. 