### PR TITLE
POC refactor to return submittable extrinsic

### DIFF
--- a/src/parachain/transaction.ts
+++ b/src/parachain/transaction.ts
@@ -8,6 +8,7 @@ import type { AnyTuple } from "@polkadot/types/types";
 import { ACCOUNT_NOT_SET_ERROR_MESSAGE, IGNORED_ERROR_MESSAGES } from "../utils/constants";
 
 export interface TransactionAPI {
+    api: ApiPromise;
     setAccount(account: AddressOrPair): void;
     removeAccount(): void;
     getAccount(): AddressOrPair | undefined;
@@ -32,7 +33,7 @@ export interface TransactionAPI {
 }
 
 export class DefaultTransactionAPI implements TransactionAPI {
-    constructor(public api: ApiPromise, private account?: AddressOrPair) { }
+    constructor(public api: ApiPromise, private account?: AddressOrPair) {}
 
     public setAccount(account: AddressOrPair): void {
         this.account = account;

--- a/src/types/extrinsic.ts
+++ b/src/types/extrinsic.ts
@@ -1,0 +1,5 @@
+import { SubmittableExtrinsic, ApiTypes, AugmentedEvent } from "@polkadot/api/types";
+
+type ExtrinsicData = [SubmittableExtrinsic<ApiTypes>, AugmentedEvent<ApiTypes>];
+
+export type { ExtrinsicData };

--- a/src/utils/extrinsic-handler.ts
+++ b/src/utils/extrinsic-handler.ts
@@ -1,22 +1,71 @@
 import { SubmittableExtrinsic, ApiTypes, AugmentedEvent } from "@polkadot/api/types";
 import { ISubmittableResult } from "@polkadot/types/types";
+import { newMonetaryAmount, tokenSymbolToCurrency } from "./currency";
 import { TransactionAPI } from "../parachain";
-
+import { Currency, MonetaryAmount } from "@interlay/monetary-js";
+/**
+ * This class exposes extrinsic metadata and allows simple extrinsic submission,
+ * fee estimation or batching with other extrinsics.
+ */
 class ExtrinsicHandler {
     constructor(
         private transactionAPI: TransactionAPI,
-        public extrinsic: SubmittableExtrinsic<ApiTypes>,
-        public event: AugmentedEvent<ApiTypes>
+        public extrinsic: SubmittableExtrinsic<"promise">,
+        public event?: AugmentedEvent<"promise">
     ) {}
 
-    public async submit(onlyInBlock: boolean = true): Promise<ISubmittableResult> {
+    /**
+     * Getter for fee estimation of the extrinsic.
+     *
+     * @returns {MonetaryAmount<Currency>} amount of native currency that will be paid as transaction fee.
+     * @note This fee estimation does not include tip.
+     */
+    public async getFeeEstimation(): Promise<MonetaryAmount<Currency>> {
+        const nativeCurrency = tokenSymbolToCurrency(
+            this.transactionAPI.api.consts.currency.getNativeCurrencyId.asToken
+        );
+
+        const account = this.transactionAPI.getAccount();
+        if (account === undefined) {
+            return newMonetaryAmount(0, nativeCurrency);
+        }
+
+        const paymentInfo = await this.extrinsic.paymentInfo(account);
+        return newMonetaryAmount(paymentInfo.partialFee.toString(), nativeCurrency);
+    }
+
+    /**
+     * This method submits the extrinsic signed by account set in TransactionAPI. Wrapper around TransactionAPI.sendLogged.
+     *
+     * @param {boolean} onlyInBlock Optional parameter to set waiting for transaction inclusion only (true) or finalisation (false).
+     *                              Defaults to true.
+     * @returns {ISubmittableResult} Result of the extrinsic submission.
+     */
+    public submit(onlyInBlock: boolean = true): Promise<ISubmittableResult> {
         return this.transactionAPI.sendLogged(this.extrinsic, this.event, onlyInBlock);
     }
 
+    /**
+     * Batch current and another extrinsic together.
+     *
+     * @param {ExtrinsicHandler} extrinsicToBatchWith Another extrinsic that will be batched with current extrinsic.
+     * @param {boolean} atomic Optional parameter to set whether the extrinsics execution should be atomic or not. Defaults to true.
+     * @returns {ExtrinsicHandler} New instance of this class with batched extrinsics.
+     * @note Passed extrinsic is added after the current one into batch. Therefore, order of execution
+     *       is defined by choosing the instance this method is called this on.
+     */
     public batchWith(extrinsicToBatchWith: ExtrinsicHandler, atomic: boolean = true): ExtrinsicHandler {
         return this.batchWithRawExtrinsic(extrinsicToBatchWith.extrinsic, atomic);
     }
 
+    /**
+     * Batch current extrinsic with another raw extrinsic.
+     *
+     * @param {SubmittableExtrinsic<ApiTypes>} extrinsicToBatchWith Raw extrinsic that will be batched with current extrinsic.
+     * @param {boolean} atomic Optional parameter to set whether the extrinsics execution should be atomic or not. Defaults to true.
+     * @returns {ExtrinsicHandler} New instance of this class with batched extrinsics.
+     * @note Passed extrinsic is added after the current one into batch.
+     */
     public batchWithRawExtrinsic(
         rawExtrinsicToBatchWith: SubmittableExtrinsic<ApiTypes>,
         atomic: boolean = true

--- a/src/utils/extrinsic-handler.ts
+++ b/src/utils/extrinsic-handler.ts
@@ -1,0 +1,34 @@
+import { SubmittableExtrinsic, ApiTypes, AugmentedEvent } from "@polkadot/api/types";
+import { ISubmittableResult } from "@polkadot/types/types";
+import { TransactionAPI } from "../parachain";
+
+class ExtrinsicHandler {
+    constructor(
+        private transactionAPI: TransactionAPI,
+        public extrinsic: SubmittableExtrinsic<ApiTypes>,
+        public event: AugmentedEvent<ApiTypes>
+    ) {}
+
+    public async submit(onlyInBlock: boolean = true): Promise<ISubmittableResult> {
+        return this.transactionAPI.sendLogged(this.extrinsic, this.event, onlyInBlock);
+    }
+
+    public batchWith(extrinsicToBatchWith: ExtrinsicHandler, atomic: boolean = true): ExtrinsicHandler {
+        return this.batchWithRawExtrinsic(extrinsicToBatchWith.extrinsic, atomic);
+    }
+
+    public batchWithRawExtrinsic(
+        rawExtrinsicToBatchWith: SubmittableExtrinsic<ApiTypes>,
+        atomic: boolean = true
+    ): ExtrinsicHandler {
+        const batchExtrinsic = this.transactionAPI.buildBatchExtrinsic(
+            [this.extrinsic, rawExtrinsicToBatchWith],
+            atomic
+        );
+        const batchEvent = this.transactionAPI.api.events.utility.BatchCompleted;
+
+        return new ExtrinsicHandler(this.transactionAPI, batchExtrinsic, batchEvent);
+    }
+}
+
+export { ExtrinsicHandler };


### PR DESCRIPTION
Opening up POC PR with proposed refactor of how the submission of extrinsics is handled in lib, issue https://github.com/interlay/interbtc-api/issues/592

This refactor introduces `ExtrinsicHandler` class that contains `SubmittableExtrinsic`, optional event type and helper methods for submission, fee estimation and batching. 

I edited AMM module to show how we can easily refactor lib methods to use this approach.

### UI side usage example
**Access `SubmittableExtrinsic` members**
```typescript
const swapExtrinsic = window.bridge.amm.swap(trade);
const submittableExtrinsic = swapExtrinsic.extrinsic;
```
**Submit extrinsic**
```typescript
const swapExtrinsic = window.bridge.amm.swap(trade);
await swapExtrinsic.submit();
```

**Get fee estimation**
```typescript
const swapExtrinsic = window.bridge.amm.swap(trade);
const fee = await swapExtrinsic.getFeeEstimation();
```

**Compose with another extrinsic**
```typescript
// swap and add liquidity
const swapExtrinsic = window.bridge.amm.swap(trade);
const addLiquidityExtrinsic = window.bridge.amm.addLiquidity(params);
const swapAndAddLiquidityExtrinsic = swapExtrinsic.batchWith(addLiquidityExtrinsic);

// submit batched extrinsics
await swapAndAddLiquidityExtrinsic.submit();
```

