### PR TITLE
Feat: Also return total amount staking on rewards estimate

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@interlay/interbtc-api",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "JavaScript library to interact with interBTC",
   "main": "build/src/index.js",
   "typings": "build/src/index.d.ts",

--- a/src/interbtc-api.ts
+++ b/src/interbtc-api.ts
@@ -112,7 +112,7 @@ export class DefaultInterBtcApi implements InterBtcApi {
         this.system = new DefaultSystemAPI(api);
         this.fee = new DefaultFeeAPI(api, this.oracle);
         this.rewards = new DefaultRewardsAPI(api, wrappedCurrency);
-        this.escrow = new DefaultEscrowAPI(api, governanceCurrency);
+        this.escrow = new DefaultEscrowAPI(api, governanceCurrency, this.system);
 
         this.vaults = new DefaultVaultsAPI(
             api,

--- a/src/parachain/escrow.ts
+++ b/src/parachain/escrow.ts
@@ -92,15 +92,14 @@ export interface EscrowAPI {
      *                      Zero, null, or undefined are interpreted as no changes to the current stake for the estimation.
      * @param newLockEndHeight (optional) At which block number the stake lock should end.
      *                          Zero, null, or undefined are interpreted as no lock extension used for the estimate.
-     * @returns The estimated annualized reward as amount and percentage (APY).
+     * @returns The estimated total reward amount and annualized reward percentage (APY).
      */
     getRewardEstimate(
         accountId: AccountId,
         amountToLock?: MonetaryAmount<GovernanceCurrency>,
         newLockEndHeight?: number
     ): Promise<{
-        amountAnnualized: MonetaryAmount<GovernanceCurrency>;
-        amountTotal: MonetaryAmount<GovernanceCurrency>;
+        amount: MonetaryAmount<GovernanceCurrency>;
         apy: Big;
     }>;
 }
@@ -150,8 +149,7 @@ export class DefaultEscrowAPI implements EscrowAPI {
         amountToLock?: MonetaryAmount<GovernanceCurrency>,
         newLockEndHeight?: number
     ): Promise<{
-        amountAnnualized: MonetaryAmount<GovernanceCurrency>;
-        amountTotal: MonetaryAmount<GovernanceCurrency>;
+        amount: MonetaryAmount<GovernanceCurrency>;
         apy: Big;
     }> {
         const stakedBalance = await this.getStakedBalance(accountId);
@@ -174,8 +172,7 @@ export class DefaultEscrowAPI implements EscrowAPI {
         // if there is no staked amount and no added amount to be checked, return 0
         if (atomicStakedAmount.eq(Big(0))) {
             return {
-                amountAnnualized: newMonetaryAmount(0, this.governanceCurrency),
-                amountTotal: newMonetaryAmount(0, this.governanceCurrency),
+                amount: newMonetaryAmount(0, this.governanceCurrency),
                 apy: Big(0),
             };
         }
@@ -201,8 +198,7 @@ export class DefaultEscrowAPI implements EscrowAPI {
         const rewardAmountTotal = rewardAmountAnnualized.mul(effectiveLockEndHeight - currentHeight).div(blocksPerYear);
 
         return {
-            amountAnnualized: rewardAmountAnnualized,
-            amountTotal: rewardAmountTotal,
+            amount: rewardAmountTotal,
             apy: rewardRate.mul(100),
         };
     }

--- a/test/integration/parachain/staging/sequential/escrow.test.ts
+++ b/test/integration/parachain/staging/sequential/escrow.test.ts
@@ -103,12 +103,8 @@ describe("escrow", () => {
         const expected = new Big(0);
         assert.isTrue(expected.eq(rewardsEstimate.apy), `APY should be 0, but is ${rewardsEstimate.apy.toString()}`);
         assert.isTrue(
-            rewardsEstimate.amountAnnualized.isZero(),
-            `Annualized rewards should be 0, but are ${rewardsEstimate.amountAnnualized.toHuman()}`
-        );
-        assert.isTrue(
-            rewardsEstimate.amountTotal.isZero(),
-            `Total rewards should be 0, but are ${rewardsEstimate.amountTotal.toHuman()}`
+            rewardsEstimate.amount.isZero(),
+            `Rewards should be 0, but are ${rewardsEstimate.amount.toHuman()}`
         );
     });
 
@@ -148,26 +144,12 @@ describe("escrow", () => {
         );
 
         const account1 = newAccountId(api, userAccount1.address);
-        const stake = await getEscrowStake(api, account1);
-        const totalStake = await getEscrowTotalStake(api);
-        let rewardPerToken = await getEscrowRewardPerToken(interBtcAPI);
-        // estimate RPC withdraws rewards first
-        const rewardTally = stake.mul(rewardPerToken);
-        // update with previous rewards
-        rewardPerToken = rewardPerToken.add(new Big(firstYearRewards).div(totalStake));
 
-        const expectedRewards = newMonetaryAmount(
-            // rewardPerToken = rewardPerToken + reward / totalStake
-            // stake * rewardPerToken - rewardTally
-            stake.mul(rewardPerToken).sub(rewardTally),
-            interBtcAPI.getGovernanceCurrency()
-        );
         const rewardsEstimate = await interBtcAPI.escrow.getRewardEstimate(account1);
 
         assert.isTrue(
-            expectedRewards.toBig().div(rewardsEstimate.amountAnnualized.toBig()).lt(1.1) &&
-                expectedRewards.toBig().div(rewardsEstimate.amountAnnualized.toBig()).gt(0.9),
-            "The estimate should be within 10% of the actual first year rewards"
+            rewardsEstimate.amount.toBig().gt(0),
+            `Expected reward to be a positive amount, got ${rewardsEstimate.amount.toString()}`
         );
         assert.isTrue(
             rewardsEstimate.apy.gte(100),

--- a/test/integration/parachain/staging/sequential/escrow.test.ts
+++ b/test/integration/parachain/staging/sequential/escrow.test.ts
@@ -103,8 +103,12 @@ describe("escrow", () => {
         const expected = new Big(0);
         assert.isTrue(expected.eq(rewardsEstimate.apy), `APY should be 0, but is ${rewardsEstimate.apy.toString()}`);
         assert.isTrue(
-            rewardsEstimate.amount.isZero(),
-            `Rewards should be 0, but are ${rewardsEstimate.amount.toHuman()}`
+            rewardsEstimate.amountAnnualized.isZero(),
+            `Annualized rewards should be 0, but are ${rewardsEstimate.amountAnnualized.toHuman()}`
+        );
+        assert.isTrue(
+            rewardsEstimate.amountTotal.isZero(),
+            `Total rewards should be 0, but are ${rewardsEstimate.amountTotal.toHuman()}`
         );
     });
 
@@ -161,8 +165,8 @@ describe("escrow", () => {
         const rewardsEstimate = await interBtcAPI.escrow.getRewardEstimate(account1);
 
         assert.isTrue(
-            expectedRewards.toBig().div(rewardsEstimate.amount.toBig()).lt(1.1) &&
-                expectedRewards.toBig().div(rewardsEstimate.amount.toBig()).gt(0.9),
+            expectedRewards.toBig().div(rewardsEstimate.amountAnnualized.toBig()).lt(1.1) &&
+                expectedRewards.toBig().div(rewardsEstimate.amountAnnualized.toBig()).gt(0.9),
             "The estimate should be within 10% of the actual first year rewards"
         );
         assert.isTrue(


### PR DESCRIPTION
❗ BREAKING ❗ 

Changes the API return value on `escrow.getRewardEstimate`: now returns total reward amount instead of the annualized value.