### PR TITLE
chore: bump version to 2.2.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@interlay/interbtc-api",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "description": "JavaScript library to interact with interBTC",
   "main": "build/src/index.js",
   "typings": "build/src/index.d.ts",


### PR DESCRIPTION
Bumping version for monetary.js update - necessary to be able to update monetary.js on UI side.