### PR TITLE
fix(loans): make subsidy reward index same as in the parachain

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@interlay/interbtc-api",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "JavaScript library to interact with interBTC",
   "main": "build/src/index.js",
   "typings": "build/src/index.d.ts",

--- a/src/parachain/loans.ts
+++ b/src/parachain/loans.ts
@@ -833,7 +833,6 @@ export class DefaultLoansAPI implements LoansAPI {
                 lend: lendReward.toBig().gt(0) ? lendReward : null,
                 borrow: borrowReward.toBig().gt(0) ? borrowReward : null,
             };
-            console.log(underlyingCurrency.ticker, "lend", lendReward.toString(), "borrow", borrowReward.toString());
             totalRewards = totalRewards.add(lendReward).add(borrowReward);
         }
         return { total: totalRewards, perMarket: rewardsPerMarket };


### PR DESCRIPTION
Fixes accrued reward calculation to match the decimals used on parachain side.
Solves part of the https://github.com/interlay/interbtc-ui/issues/1265