### PR TITLE
fix(loans): use universal scaling factor to compute index independent…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@interlay/interbtc-api",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "JavaScript library to interact with interBTC",
   "main": "build/src/index.js",
   "typings": "build/src/index.d.ts",

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -24,3 +24,5 @@ export function sleep(ms: number): Promise<void> {
 
 // Decimal precision of Newton's approximations that are computed in this class.
 export const STABLE_POOLS_APPROXIMATION_PRECISION = Big(10).pow(9);
+
+export const LOANS_REWARD_INDEX_SCALING_FACTOR = 10 ** 12;


### PR DESCRIPTION
… of reward currency decimals

Loans reward index computation was incorrectly scaled down by reward currency decimals. It has to always be to the factor of `10**12`.