### PR TITLE
chore: fix wrong tagging

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@interlay/interbtc-api",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "description": "JavaScript library to interact with interBTC",
   "main": "build/src/index.js",
   "typings": "build/src/index.d.ts",


### PR DESCRIPTION
Have to bump version to `2.3.3` because of incorrect tagging of `2.3.2` being already released to NPM.