### PR TITLE
fix(amm): read farming reward curencies from farmingRewards pallet

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@interlay/interbtc-api",
-  "version": "2.3.4",
+  "version": "2.3.5",
   "description": "JavaScript library to interact with interBTC",
   "main": "build/src/index.js",
   "typings": "build/src/index.d.ts",

--- a/src/parachain/amm.ts
+++ b/src/parachain/amm.ts
@@ -597,12 +597,9 @@ export class DefaultAMMAPI implements AMMAPI {
     private async _getFarmingRewardCurrencyIds(
         lpTokenCurrencyId: InterbtcPrimitivesCurrencyId
     ): Promise<Array<InterbtcPrimitivesCurrencyId>> {
-        const rewardCurrencies: Array<InterbtcPrimitivesCurrencyId> = [];
-
         const rewardCurrenciesRaw = await this.api.query.farmingRewards.rewardCurrencies(lpTokenCurrencyId);
-        rewardCurrenciesRaw.forEach((rewardCurrencyId: InterbtcPrimitivesCurrencyId) =>
-            rewardCurrencies.push(rewardCurrencyId)
-        );
+
+        const rewardCurrencies = Array.from(rewardCurrenciesRaw.values());
 
         return rewardCurrencies;
     }


### PR DESCRIPTION
Fixing farming reward currencies fetching for `amm.getClaimableFarmingRewards` in case the farming rewards are over, but there are still pending unclaimed rewards.

[Thread](https://discord.com/channels/745259537707040778/1123855798611759104/1123855953289293887)