### PR TITLE
Peter/fix qtoken exchange rate

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@interlay/interbtc-api",
-  "version": "2.3.5",
+  "version": "2.3.6",
   "description": "JavaScript library to interact with interBTC",
   "main": "build/src/index.js",
   "typings": "build/src/index.d.ts",


### PR DESCRIPTION
Fixing exchange rate computation for qTokens, we need to unwrap the underlying currency id first - before using it in another call.