### PR TITLE
chore: update types

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   "engineStrict": true,
   "dependencies": {
     "@interlay/esplora-btc-api": "0.4.0",
-    "@interlay/interbtc-types": "1.12.0",
+    "@interlay/interbtc-types": "1.13.0",
     "@interlay/monetary-js": "0.7.3",
     "@polkadot/api": "9.14.2",
     "big.js": "6.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@interlay/interbtc-api",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "JavaScript library to interact with interBTC",
   "main": "build/src/index.js",
   "typings": "build/src/index.d.ts",


### PR DESCRIPTION
Updating types to `1.13.0` to contain `Escrow.FreeStakable` call.