### PR TITLE
Fix: manual def transactionpaymentapi queryinfo

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@interlay/interbtc-api",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "JavaScript library to interact with interBTC",
   "main": "build/src/index.js",
   "typings": "build/src/index.d.ts",

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -29,7 +29,13 @@ export function createSubstrateAPI(
 
     const types = getAPITypes();
     const rpc = getRPCTypes();
-    return ApiPromise.create({ provider, types, rpc, noInitWarn: noInitWarn || true });
+    return ApiPromise.create({
+        provider,
+        types,
+        rpc,
+        noInitWarn: noInitWarn || true,
+        runtime: definitions.default.runtime
+    });
 }
 
 export async function createInterBtcApi(

--- a/src/interfaces/definitions.ts
+++ b/src/interfaces/definitions.ts
@@ -3,6 +3,31 @@ export default {
     types: definitions.types[0].types,
     rpc: parseProviderRpcDefinitions(definitions.rpc),
     providerRpc: definitions.rpc,
+    // manual definition for transactionPaymentApi.queryInfo until polkadot-js/api can be upgraded
+    // TODO: revert when this work is merged: https://github.com/interlay/interbtc-api/pull/672
+    runtime: {
+        TransactionPaymentApi: [
+            {
+                methods: {
+                    queryInfo: {
+                        description: 'Retrieves the fee information for an encoded extrinsic',
+                        params: [
+                            {
+                                name: 'uxt',
+                                type: 'Extrinsic'
+                            },
+                            {
+                                name: 'len',
+                                type: 'u32'
+                            }
+                        ],
+                        type: 'RuntimeDispatchInfo'
+                    }
+                },
+                version: 4
+            }
+        ]
+    }
 };
 
 function parseProviderRpcDefinitions(


### PR DESCRIPTION
Resolves #673 

Add manual runtime definition for `transactionPaymentApi.queryInfo` as quick patch until we are able to properly upgrade to polkadot-js/api `10.3.1` or newer.