### PR TITLE
Refactor: replace fs.readFileSync

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@interlay/interbtc-api",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "JavaScript library to interact with interBTC",
   "main": "build/src/index.js",
   "type": "module",

--- a/src/interfaces/definitions.ts
+++ b/src/interfaces/definitions.ts
@@ -1,9 +1,9 @@
 import { RpcFunctionDefinition } from "@interlay/interbtc-types";
-import fs from "fs";
+import { createRequire } from "module";
 
-// hacky, but cannot import json "the old way" in esnext
-const definitionsString = fs.readFileSync("./node_modules/@interlay/interbtc-types/definitions.json", "utf-8");
-const definitions = JSON.parse(definitionsString);
+// need to use "require" to be able to import json file from @interlay/interbtc-types
+const require = createRequire(import.meta.url);
+const definitions = require("@interlay/interbtc-types/definitions.json");
 
 interface DecoratedRpcFunctionDefinition extends RpcFunctionDefinition {
     aliasSection: string;

--- a/src/interfaces/definitions.ts
+++ b/src/interfaces/definitions.ts
@@ -2,8 +2,8 @@ import { RpcFunctionDefinition } from "@interlay/interbtc-types";
 import { createRequire } from "module";
 
 // need to use "require" to be able to import json file from @interlay/interbtc-types
-const require = createRequire(import.meta.url);
-const definitions = require("@interlay/interbtc-types/definitions.json");
+const moduleRequire = createRequire(import.meta.url);
+const definitions = moduleRequire("@interlay/interbtc-types/definitions.json");
 
 interface DecoratedRpcFunctionDefinition extends RpcFunctionDefinition {
     aliasSection: string;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,8 +4,8 @@
     },
     "compilerOptions": {
         "skipLibCheck": true,
-        "target": "ES6",
-        "module": "ES6",
+        "target": "esnext",
+        "module": "esnext",
         "outDir": "build",
         "declaration": true,
         "strict": true,


### PR DESCRIPTION
Replace `fs.readFileSync` which causes issues in our UI with a `require` workaround to be able to import `definitions.json` from `interbtc-types`.

Changed module from es6 to esnext - the latter supports `createRequire(import.meta.url)`