### PR TITLE
Chore: bump version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@interlay/interbtc-api",
-  "version": "2.6.0-rc.0",
+  "version": "2.6.0",
   "description": "JavaScript library to interact with interBTC",
   "main": "build/cjs/src/index.js",
   "module": "build/esm/src/index.js",

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -5,3 +5,4 @@ export * from "./vault";
 export * from "./loans";
 export * from "./extrinsic";
 export * from "./encoding";
+export * from "./oracleTypes";

--- a/src/utils/issueRedeem.ts
+++ b/src/utils/issueRedeem.ts
@@ -69,7 +69,7 @@ export function getRequestIdsFromEvents(
     eventToFind: AugmentedEvent<ApiTypes, AnyTuple>,
     api: ApiPromise
 ): Hash[] {
-    const ids = new Array<Hash>();
+    const ids: Hash[] = [];
     for (const { event } of events) {
         if (eventToFind.is(event)) {
             // the redeem id has type H256 and is the first item of the event data array


### PR DESCRIPTION
`2.6.0-rc.0` -> `2.6.0`

Additional changes:
- export oracle types